### PR TITLE
init workspace

### DIFF
--- a/cobble.toml
+++ b/cobble.toml
@@ -1,5 +1,6 @@
-
-
+[init]
+config = cobble_init/cobble.toml
+task = /setup
 
 [vars]
 cobble.build = "release"

--- a/cobble.toml
+++ b/cobble.toml
@@ -1,6 +1,6 @@
 [init]
-config = cobble_init/cobble.toml
-task = /setup
+workspace = "cobble_init"
+task = "/setup"
 
 [vars]
 cobble.build = "release"

--- a/cobble_init/project.lua
+++ b/cobble_init/project.lua
@@ -2,6 +2,6 @@ task {
     name = "setup",
     always_run = true,
     actions = {
-        function (c) println("INITIALIZATION!!!") end
+        function (c) print("INITIALIZATION!!!") end
     }
 }

--- a/cobble_init/project.lua
+++ b/cobble_init/project.lua
@@ -2,6 +2,6 @@ task {
     name = "setup",
     always_run = true,
     actions = {
-        function (c) print("INITIALIZATION!!!") end
+        function (c) c.println("INITIALIZATION!!!") end
     }
 }

--- a/cobble_init/project.lua
+++ b/cobble_init/project.lua
@@ -1,0 +1,7 @@
+task {
+    name = "setup",
+    always_run = true,
+    actions = {
+        function (c) println("INITIALIZATION!!!") end
+    }
+}

--- a/src/bin/cobl/commands/clean.rs
+++ b/src/bin/cobl/commands/clean.rs
@@ -13,6 +13,7 @@ use cobble::dependency::resolve_calculated_dependencies_in_subtrees;
 use cobble::execute::execute::TaskExecutor;
 use cobble::load::load_projects;
 use cobble::task_selection::compute_selected_tasks;
+use cobble::util::process_io::{ProcessIO, StandardIO};
 use cobble::workspace::create_workspace;
 
 use crate::commands::run::run_init_task_if_defined;
@@ -66,16 +67,17 @@ pub fn clean_command<'a>(input: CleanCommandInput) -> anyhow::Result<()> {
         config.workspace_dir.join(".cobble.db").as_path(),
     )?;
 
-    calculate_artifacts(&mut workspace, &mut executor)?;
+    calculate_artifacts(&mut workspace, &mut executor, &StandardIO)?;
 
     resolve_calculated_dependencies_in_subtrees(
         selected_tasks.iter(),
         &mut workspace,
         &mut executor,
+        &StandardIO
     )?;
 
     // Execute the tasks
-    executor.clean_tasks(&workspace, selected_tasks.iter())?;
+    executor.clean_tasks(&workspace, selected_tasks.iter(), StandardIO.out(), StandardIO.err())?;
 
     Ok(())
 }

--- a/src/bin/cobl/commands/clean.rs
+++ b/src/bin/cobl/commands/clean.rs
@@ -13,7 +13,7 @@ use cobble::dependency::resolve_calculated_dependencies_in_subtrees;
 use cobble::execute::execute::TaskExecutor;
 use cobble::load::load_projects;
 use cobble::task_selection::compute_selected_tasks;
-use cobble::util::process_io::{ProcessIO, StandardIO};
+use cobble::util::process_io::StandardIO;
 use cobble::workspace::create_workspace;
 
 use crate::commands::run::run_init_task_if_defined;
@@ -77,7 +77,7 @@ pub fn clean_command<'a>(input: CleanCommandInput) -> anyhow::Result<()> {
     )?;
 
     // Execute the tasks
-    executor.clean_tasks(&workspace, selected_tasks.iter(), StandardIO.out(), StandardIO.err())?;
+    executor.clean_tasks(&workspace, selected_tasks.iter(), &StandardIO)?;
 
     Ok(())
 }

--- a/src/bin/cobl/commands/clean.rs
+++ b/src/bin/cobl/commands/clean.rs
@@ -73,7 +73,7 @@ pub fn clean_command<'a>(input: CleanCommandInput) -> anyhow::Result<()> {
         selected_tasks.iter(),
         &mut workspace,
         &mut executor,
-        &StandardIO
+        &StandardIO,
     )?;
 
     // Execute the tasks

--- a/src/bin/cobl/commands/clean.rs
+++ b/src/bin/cobl/commands/clean.rs
@@ -15,6 +15,8 @@ use cobble::load::load_projects;
 use cobble::task_selection::compute_selected_tasks;
 use cobble::workspace::create_workspace;
 
+use crate::commands::run::run_init_task_if_defined;
+
 pub struct CleanCommandInput {
     pub cwd: PathBuf,
     pub tasks: Vec<String>,
@@ -39,6 +41,9 @@ pub fn clean_command<'a>(input: CleanCommandInput) -> anyhow::Result<()> {
         ..Default::default()
     };
     let config = Arc::new(get_workspace_config(cwd.as_path(), &ws_config_args)?);
+
+    run_init_task_if_defined(&cwd, &config)?;
+
     set_current_dir(&config.workspace_dir)
         .expect("found the workspace directory, so we should be able to set that as the cwd");
 

--- a/src/bin/cobl/commands/env.rs
+++ b/src/bin/cobl/commands/env.rs
@@ -7,12 +7,7 @@ use anyhow::anyhow;
 use std::{env::set_current_dir, path::PathBuf, sync::Arc};
 
 use cobble::{
-    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs},
-    dependency::resolve_calculated_dependencies_in_subtrees,
-    execute::execute::TaskExecutor,
-    load::load_projects,
-    task_selection::compute_selected_envs,
-    workspace::create_workspace,
+    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs}, dependency::resolve_calculated_dependencies_in_subtrees, execute::execute::TaskExecutor, load::load_projects, task_selection::compute_selected_envs, util::process_io::{ProcessIO, StandardIO}, workspace::create_workspace
 };
 
 use crate::commands::run::run_init_task_if_defined;
@@ -78,7 +73,7 @@ pub fn run_env_command(input: RunEnvInput) -> anyhow::Result<()> {
         config.clone(),
         config.workspace_dir.join(".cobble.db").as_path(),
     )?;
-    resolve_calculated_dependencies_in_subtrees(setup_tasks.iter(), &mut workspace, &mut executor)?;
+    resolve_calculated_dependencies_in_subtrees(setup_tasks.iter(), &mut workspace, &mut executor, &StandardIO)?;
 
     let mut executor = TaskExecutor::new(
         config.clone(),
@@ -87,7 +82,7 @@ pub fn run_env_command(input: RunEnvInput) -> anyhow::Result<()> {
 
     let args_arcs: Vec<Arc<str>> = args.into_iter().map(|s| s.into()).collect();
 
-    executor.do_env_actions(&workspace, selected_envs.iter(), &args_arcs)?;
+    executor.do_env_actions(&workspace, selected_envs.iter(), &args_arcs, StandardIO.out(), StandardIO.err())?;
 
     Ok(())
 }

--- a/src/bin/cobl/commands/env.rs
+++ b/src/bin/cobl/commands/env.rs
@@ -7,7 +7,13 @@ use anyhow::anyhow;
 use std::{env::set_current_dir, path::PathBuf, sync::Arc};
 
 use cobble::{
-    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs}, dependency::resolve_calculated_dependencies_in_subtrees, execute::execute::TaskExecutor, load::load_projects, task_selection::compute_selected_envs, util::process_io::StandardIO, workspace::create_workspace
+    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs},
+    dependency::resolve_calculated_dependencies_in_subtrees,
+    execute::execute::TaskExecutor,
+    load::load_projects,
+    task_selection::compute_selected_envs,
+    util::process_io::StandardIO,
+    workspace::create_workspace,
 };
 
 use crate::commands::run::run_init_task_if_defined;
@@ -73,7 +79,12 @@ pub fn run_env_command(input: RunEnvInput) -> anyhow::Result<()> {
         config.clone(),
         config.workspace_dir.join(".cobble.db").as_path(),
     )?;
-    resolve_calculated_dependencies_in_subtrees(setup_tasks.iter(), &mut workspace, &mut executor, &StandardIO)?;
+    resolve_calculated_dependencies_in_subtrees(
+        setup_tasks.iter(),
+        &mut workspace,
+        &mut executor,
+        &StandardIO,
+    )?;
 
     let mut executor = TaskExecutor::new(
         config.clone(),

--- a/src/bin/cobl/commands/env.rs
+++ b/src/bin/cobl/commands/env.rs
@@ -15,6 +15,8 @@ use cobble::{
     workspace::create_workspace,
 };
 
+use crate::commands::run::run_init_task_if_defined;
+
 pub struct RunEnvInput {
     pub cwd: PathBuf,
     pub envs: Vec<String>,
@@ -41,6 +43,9 @@ pub fn run_env_command(input: RunEnvInput) -> anyhow::Result<()> {
         ..Default::default()
     };
     let config = Arc::new(get_workspace_config(cwd.as_path(), &ws_config_args)?);
+
+    run_init_task_if_defined(&cwd, &config)?;
+
     set_current_dir(&config.workspace_dir)
         .expect("found the workspace directory, so we should be able to set that as the cwd");
 

--- a/src/bin/cobl/commands/env.rs
+++ b/src/bin/cobl/commands/env.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use std::{env::set_current_dir, path::PathBuf, sync::Arc};
 
 use cobble::{
-    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs}, dependency::resolve_calculated_dependencies_in_subtrees, execute::execute::TaskExecutor, load::load_projects, task_selection::compute_selected_envs, util::process_io::{ProcessIO, StandardIO}, workspace::create_workspace
+    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs}, dependency::resolve_calculated_dependencies_in_subtrees, execute::execute::TaskExecutor, load::load_projects, task_selection::compute_selected_envs, util::process_io::StandardIO, workspace::create_workspace
 };
 
 use crate::commands::run::run_init_task_if_defined;
@@ -82,7 +82,7 @@ pub fn run_env_command(input: RunEnvInput) -> anyhow::Result<()> {
 
     let args_arcs: Vec<Arc<str>> = args.into_iter().map(|s| s.into()).collect();
 
-    executor.do_env_actions(&workspace, selected_envs.iter(), &args_arcs, StandardIO.out(), StandardIO.err())?;
+    executor.do_env_actions(&workspace, selected_envs.iter(), &args_arcs, &StandardIO)?;
 
     Ok(())
 }

--- a/src/bin/cobl/commands/list.rs
+++ b/src/bin/cobl/commands/list.rs
@@ -12,6 +12,8 @@ use cobble::query::{find_tasks_for_dir, find_tasks_for_query};
 use cobble::resolve::project_path_to_project_name;
 use cobble::workspace::create_workspace;
 
+use crate::commands::run::run_init_task_if_defined;
+
 pub struct ListCommandInput {
     pub cwd: PathBuf,
     pub tasks: Vec<String>,
@@ -19,6 +21,9 @@ pub struct ListCommandInput {
 
 pub fn list_command(input: ListCommandInput) -> anyhow::Result<()> {
     let config = get_workspace_config(input.cwd.as_path(), &Default::default()).unwrap();
+
+    run_init_task_if_defined(&input.cwd, &config)?;
+
     set_current_dir(&config.workspace_dir)
         .expect("found the workspace directory, so we should be able to set that as the cwd");
 

--- a/src/bin/cobl/commands/run.rs
+++ b/src/bin/cobl/commands/run.rs
@@ -36,6 +36,8 @@ pub fn run_command(input: RunCommandInput) -> anyhow::Result<()> {
         show_stderr,
     } = input;
 
+    // Run init workspace task
+
     let ws_config_args = WorkspaceConfigArgs {
         vars,
         force_run_tasks: Some(force_run_tasks),

--- a/src/bin/cobl/commands/run.rs
+++ b/src/bin/cobl/commands/run.rs
@@ -3,6 +3,7 @@
 //
 // This program is licensed under the GPLv3.0 license (https://github.com/jdarais/cobble/blob/main/COPYING)
 
+use std::cmp;
 use std::collections::HashMap;
 use std::env::set_current_dir;
 use std::io::Write;
@@ -11,7 +12,8 @@ use std::sync::Arc;
 
 use cobble::calc_artifacts::calculate_artifacts;
 use cobble::config::{
-    get_workspace_config, parse_cli_vars, TaskOutputCondition, WorkspaceConfig, WorkspaceConfigArgs,
+    get_workspace_config, parse_cli_vars, TaskOutputCondition, WorkspaceConfig,
+    WorkspaceConfigArgs, WorkspaceInit,
 };
 use cobble::dependency::resolve_calculated_dependencies_in_subtrees;
 use cobble::execute::execute::TaskExecutor;
@@ -56,30 +58,58 @@ pub fn run_command(input: RunCommandInput) -> anyhow::Result<()> {
     )
 }
 
+fn run_init_task<P, IO>(
+    cwd: P,
+    config: &WorkspaceConfig,
+    init_config: &WorkspaceInit,
+    pio: &IO
+) -> anyhow::Result<()>
+where
+    P: AsRef<Path>,
+    IO: ProcessIO,
+{
+    let mut out = pio.out();
+    let _ = writeln!(&mut out, "# Running Init Task #");
+    let run_res = run(
+        cwd.as_ref().join(init_config.workspace_dir.as_path()),
+        vec![init_config.task.clone()],
+        config.vars.clone(),
+        config.force_run_tasks,
+        Some(config.num_threads),
+        Some(init_config.show_stdout.clone()),
+        Some(init_config.show_stderr.clone()),
+        pio,
+    );
+    let _ = writeln!(&mut out, "# Done Running Init Task #");
+    run_res
+}
+
 pub fn run_init_task_if_defined<P: AsRef<Path>>(
     cwd: P,
     config: &WorkspaceConfig,
 ) -> anyhow::Result<()> {
     match &config.init {
         Some(init_workspace) => {
-            let mut io_buffer = IOBuffer::new();
-            let mut out = io_buffer.out();
-            let _ = writeln!(&mut out, "# Running Init Task #");
-            let run_res = run(
-                cwd.as_ref().join(init_workspace.workspace_dir.as_path()),
-                vec![init_workspace.task.clone()],
-                config.vars.clone(),
-                config.force_run_tasks,
-                Some(config.num_threads),
-                Some(init_workspace.show_stdout.clone()),
-                Some(init_workspace.show_stderr.clone()),
-                &io_buffer,
-            );
-            let _ = writeln!(&mut out, "# Done Running Init Task #");
-            if let Err(_) = run_res {
-                let _ = io_buffer.flush();
+            let output_condition = cmp::max(&init_workspace.show_stderr, &init_workspace.show_stdout);
+
+            match output_condition {
+                TaskOutputCondition::Always => {
+                    run_init_task(cwd, config, init_workspace, &StandardIO)
+                }
+                TaskOutputCondition::OnFail => {
+                    let mut io_buffer = IOBuffer::new();
+                    let run_res = run_init_task(cwd, config, init_workspace, &io_buffer);
+                    
+                    if let Err(_) = run_res {
+                        let _ = io_buffer.flush();
+                    }
+                    run_res
+                }
+                TaskOutputCondition::Never => {
+                    let io_buffer = IOBuffer::new();
+                    run_init_task(cwd, config, init_workspace, &io_buffer)
+                }
             }
-            run_res
         }
         None => Ok(()),
     }

--- a/src/bin/cobl/commands/run.rs
+++ b/src/bin/cobl/commands/run.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::env::set_current_dir;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -15,6 +16,7 @@ use cobble::execute::execute::TaskExecutor;
 use cobble::load::load_projects;
 use cobble::project_def::types::TaskVar;
 use cobble::task_selection::compute_selected_tasks;
+use cobble::util::process_io::{ProcessIO, StandardIO, IOBuffer};
 use cobble::workspace::create_workspace;
 
 pub struct RunCommandInput {
@@ -40,14 +42,16 @@ pub fn run_command(input: RunCommandInput) -> anyhow::Result<()> {
 
     let parsed_vars = parse_cli_vars(vars.iter())?;
 
-    run(cwd, tasks, parsed_vars, force_run_tasks, num_threads, show_stdout, show_stderr)
+    run(cwd, tasks, parsed_vars, force_run_tasks, num_threads, show_stdout, show_stderr, &StandardIO)
 }
 
 pub fn run_init_task_if_defined<P: AsRef<Path>>(cwd: P, config: &WorkspaceConfig) -> anyhow::Result<()> {
     match &config.init {
         Some(init_workspace) => {
-            println!("# Running Init Task #");
-            run(
+            let mut io_buffer = IOBuffer::new();
+            let mut out = io_buffer.out();
+            writeln!(&mut out, "# Running Init Task #");
+            let run_res = run(
                 cwd.as_ref().join(init_workspace.workspace_dir.as_path()),
                 vec![init_workspace.task.clone()],
                 config.vars.clone(),
@@ -55,15 +59,19 @@ pub fn run_init_task_if_defined<P: AsRef<Path>>(cwd: P, config: &WorkspaceConfig
                 Some(config.num_threads),
                 Some(init_workspace.show_stdout.clone()),
                 Some(init_workspace.show_stderr.clone()),
-            )?;
-            println!("# Done Running Init Task #");
-            Ok(())
+                &io_buffer
+            );
+            writeln!(&mut out, "# Done Running Init Task #");
+            if let Err(_) = run_res {
+                let _ = io_buffer.flush();
+            }
+            run_res
         }
         None => Ok(())
     }
 }
 
-pub fn run(
+pub fn run<IO: ProcessIO>(
     cwd: PathBuf,
     tasks: Vec<String>,
     vars: HashMap<String, TaskVar>,
@@ -71,7 +79,9 @@ pub fn run(
     num_threads: Option<u8>,
     show_stdout: Option<TaskOutputCondition>,
     show_stderr: Option<TaskOutputCondition>,
+    pio: &IO
 ) -> anyhow::Result<()> {
+    let mut out = pio.out();
 
     let ws_config_args = WorkspaceConfigArgs {
         vars,
@@ -114,18 +124,19 @@ pub fn run(
         config.workspace_dir.join(".cobble.db").as_path(),
     )?;
 
-    println!("# Computing calculated artifacts #");
-    calculate_artifacts(&mut workspace, &mut executor)?;
+    writeln!(&mut out, "# Computing calculated artifacts #");
+    calculate_artifacts(&mut workspace, &mut executor, pio)?;
 
-    println!("# Computing calculated dependencies #");
+    writeln!(&mut out, "# Computing calculated dependencies #");
     resolve_calculated_dependencies_in_subtrees(
         selected_tasks.iter(),
         &mut workspace,
         &mut executor,
+        pio
     )?;
 
-    println!("# Executing tasks #");
-    executor.execute_tasks(&workspace, selected_tasks.iter())?;
+    writeln!(&mut out, "# Executing tasks #");
+    executor.execute_tasks(&workspace, selected_tasks.iter(), pio.out(), pio.err())?;
 
     Ok(())
 }

--- a/src/bin/cobl/commands/run.rs
+++ b/src/bin/cobl/commands/run.rs
@@ -10,13 +10,15 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use cobble::calc_artifacts::calculate_artifacts;
-use cobble::config::{get_workspace_config, parse_cli_vars, TaskOutputCondition, WorkspaceConfig, WorkspaceConfigArgs};
+use cobble::config::{
+    get_workspace_config, parse_cli_vars, TaskOutputCondition, WorkspaceConfig, WorkspaceConfigArgs,
+};
 use cobble::dependency::resolve_calculated_dependencies_in_subtrees;
 use cobble::execute::execute::TaskExecutor;
 use cobble::load::load_projects;
 use cobble::project_def::types::TaskVar;
 use cobble::task_selection::compute_selected_tasks;
-use cobble::util::process_io::{ProcessIO, StandardIO, IOBuffer};
+use cobble::util::process_io::{IOBuffer, ProcessIO, StandardIO};
 use cobble::workspace::create_workspace;
 
 pub struct RunCommandInput {
@@ -42,10 +44,22 @@ pub fn run_command(input: RunCommandInput) -> anyhow::Result<()> {
 
     let parsed_vars = parse_cli_vars(vars.iter())?;
 
-    run(cwd, tasks, parsed_vars, force_run_tasks, num_threads, show_stdout, show_stderr, &StandardIO)
+    run(
+        cwd,
+        tasks,
+        parsed_vars,
+        force_run_tasks,
+        num_threads,
+        show_stdout,
+        show_stderr,
+        &StandardIO,
+    )
 }
 
-pub fn run_init_task_if_defined<P: AsRef<Path>>(cwd: P, config: &WorkspaceConfig) -> anyhow::Result<()> {
+pub fn run_init_task_if_defined<P: AsRef<Path>>(
+    cwd: P,
+    config: &WorkspaceConfig,
+) -> anyhow::Result<()> {
     match &config.init {
         Some(init_workspace) => {
             let mut io_buffer = IOBuffer::new();
@@ -59,7 +73,7 @@ pub fn run_init_task_if_defined<P: AsRef<Path>>(cwd: P, config: &WorkspaceConfig
                 Some(config.num_threads),
                 Some(init_workspace.show_stdout.clone()),
                 Some(init_workspace.show_stderr.clone()),
-                &io_buffer
+                &io_buffer,
             );
             let _ = writeln!(&mut out, "# Done Running Init Task #");
             if let Err(_) = run_res {
@@ -67,7 +81,7 @@ pub fn run_init_task_if_defined<P: AsRef<Path>>(cwd: P, config: &WorkspaceConfig
             }
             run_res
         }
-        None => Ok(())
+        None => Ok(()),
     }
 }
 
@@ -79,7 +93,7 @@ pub fn run<IO: ProcessIO>(
     num_threads: Option<u8>,
     show_stdout: Option<TaskOutputCondition>,
     show_stderr: Option<TaskOutputCondition>,
-    pio: &IO
+    pio: &IO,
 ) -> anyhow::Result<()> {
     let mut out = pio.out();
 
@@ -94,9 +108,8 @@ pub fn run<IO: ProcessIO>(
 
     run_init_task_if_defined(&cwd, &config)?;
 
-    
     set_current_dir(&config.workspace_dir)
-    .expect("found the workspace directory, so we should be able to set that as the cwd");
+        .expect("found the workspace directory, so we should be able to set that as the cwd");
 
     let projects = load_projects(
         config.workspace_dir.as_path(),
@@ -132,7 +145,7 @@ pub fn run<IO: ProcessIO>(
         selected_tasks.iter(),
         &mut workspace,
         &mut executor,
-        pio
+        pio,
     )?;
 
     let _ = writeln!(&mut out, "# Executing tasks #");

--- a/src/bin/cobl/commands/run.rs
+++ b/src/bin/cobl/commands/run.rs
@@ -3,15 +3,17 @@
 //
 // This program is licensed under the GPLv3.0 license (https://github.com/jdarais/cobble/blob/main/COPYING)
 
+use std::collections::HashMap;
 use std::env::set_current_dir;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use cobble::calc_artifacts::calculate_artifacts;
-use cobble::config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs};
+use cobble::config::{get_workspace_config, parse_cli_vars, TaskOutputCondition, WorkspaceConfig, WorkspaceConfigArgs};
 use cobble::dependency::resolve_calculated_dependencies_in_subtrees;
 use cobble::execute::execute::TaskExecutor;
 use cobble::load::load_projects;
+use cobble::project_def::types::TaskVar;
 use cobble::task_selection::compute_selected_tasks;
 use cobble::workspace::create_workspace;
 
@@ -36,7 +38,40 @@ pub fn run_command(input: RunCommandInput) -> anyhow::Result<()> {
         show_stderr,
     } = input;
 
-    // Run init workspace task
+    let parsed_vars = parse_cli_vars(vars.iter())?;
+
+    run(cwd, tasks, parsed_vars, force_run_tasks, num_threads, show_stdout, show_stderr)
+}
+
+pub fn run_init_task_if_defined<P: AsRef<Path>>(cwd: P, config: &WorkspaceConfig) -> anyhow::Result<()> {
+    match &config.init {
+        Some(init_workspace) => {
+            println!("# Running Init Task #");
+            run(
+                cwd.as_ref().join(init_workspace.workspace_dir.as_path()),
+                vec![init_workspace.task.clone()],
+                config.vars.clone(),
+                config.force_run_tasks,
+                Some(config.num_threads),
+                Some(init_workspace.show_stdout.clone()),
+                Some(init_workspace.show_stderr.clone()),
+            )?;
+            println!("# Done Running Init Task #");
+            Ok(())
+        }
+        None => Ok(())
+    }
+}
+
+pub fn run(
+    cwd: PathBuf,
+    tasks: Vec<String>,
+    vars: HashMap<String, TaskVar>,
+    force_run_tasks: bool,
+    num_threads: Option<u8>,
+    show_stdout: Option<TaskOutputCondition>,
+    show_stderr: Option<TaskOutputCondition>,
+) -> anyhow::Result<()> {
 
     let ws_config_args = WorkspaceConfigArgs {
         vars,
@@ -46,8 +81,12 @@ pub fn run_command(input: RunCommandInput) -> anyhow::Result<()> {
         show_stderr,
     };
     let config = Arc::new(get_workspace_config(cwd.as_path(), &ws_config_args)?);
+
+    run_init_task_if_defined(&cwd, &config)?;
+
+    
     set_current_dir(&config.workspace_dir)
-        .expect("found the workspace directory, so we should be able to set that as the cwd");
+    .expect("found the workspace directory, so we should be able to set that as the cwd");
 
     let projects = load_projects(
         config.workspace_dir.as_path(),

--- a/src/bin/cobl/commands/run.rs
+++ b/src/bin/cobl/commands/run.rs
@@ -50,7 +50,7 @@ pub fn run_init_task_if_defined<P: AsRef<Path>>(cwd: P, config: &WorkspaceConfig
         Some(init_workspace) => {
             let mut io_buffer = IOBuffer::new();
             let mut out = io_buffer.out();
-            writeln!(&mut out, "# Running Init Task #");
+            let _ = writeln!(&mut out, "# Running Init Task #");
             let run_res = run(
                 cwd.as_ref().join(init_workspace.workspace_dir.as_path()),
                 vec![init_workspace.task.clone()],
@@ -61,7 +61,7 @@ pub fn run_init_task_if_defined<P: AsRef<Path>>(cwd: P, config: &WorkspaceConfig
                 Some(init_workspace.show_stderr.clone()),
                 &io_buffer
             );
-            writeln!(&mut out, "# Done Running Init Task #");
+            let _ = writeln!(&mut out, "# Done Running Init Task #");
             if let Err(_) = run_res {
                 let _ = io_buffer.flush();
             }
@@ -124,10 +124,10 @@ pub fn run<IO: ProcessIO>(
         config.workspace_dir.join(".cobble.db").as_path(),
     )?;
 
-    writeln!(&mut out, "# Computing calculated artifacts #");
+    let _ = writeln!(&mut out, "# Computing calculated artifacts #");
     calculate_artifacts(&mut workspace, &mut executor, pio)?;
 
-    writeln!(&mut out, "# Computing calculated dependencies #");
+    let _ = writeln!(&mut out, "# Computing calculated dependencies #");
     resolve_calculated_dependencies_in_subtrees(
         selected_tasks.iter(),
         &mut workspace,
@@ -135,8 +135,8 @@ pub fn run<IO: ProcessIO>(
         pio
     )?;
 
-    writeln!(&mut out, "# Executing tasks #");
-    executor.execute_tasks(&workspace, selected_tasks.iter(), pio.out(), pio.err())?;
+    let _ = writeln!(&mut out, "# Executing tasks #");
+    executor.execute_tasks(&workspace, selected_tasks.iter(), pio)?;
 
     Ok(())
 }

--- a/src/bin/cobl/commands/show.rs
+++ b/src/bin/cobl/commands/show.rs
@@ -1,13 +1,7 @@
 use std::{env::set_current_dir, path::PathBuf, sync::Arc};
 
 use cobble::{
-    calc_artifacts::calculate_artifacts,
-    config::{get_workspace_config, parse_cli_vars, TaskOutputCondition, WorkspaceConfigArgs},
-    dependency::resolve_calculated_dependencies_in_subtrees,
-    execute::execute::TaskExecutor,
-    load::load_projects,
-    task_selection::compute_selected_tasks,
-    workspace::create_workspace,
+    calc_artifacts::calculate_artifacts, config::{get_workspace_config, parse_cli_vars, TaskOutputCondition, WorkspaceConfigArgs}, dependency::resolve_calculated_dependencies_in_subtrees, execute::execute::TaskExecutor, load::load_projects, task_selection::compute_selected_tasks, util::process_io::StandardIO, workspace::create_workspace
 };
 
 use crate::commands::run::run_init_task_if_defined;
@@ -73,12 +67,13 @@ pub fn show_task_command(input: ShowTaskInput) -> anyhow::Result<()> {
         config.workspace_dir.join(".cobble.db").as_path(),
     )?;
 
-    calculate_artifacts(&mut workspace, &mut executor)?;
+    calculate_artifacts(&mut workspace, &mut executor, &StandardIO)?;
 
     resolve_calculated_dependencies_in_subtrees(
         selected_tasks.iter(),
         &mut workspace,
         &mut executor,
+        &StandardIO
     )?;
 
     for task_name in selected_tasks.iter() {

--- a/src/bin/cobl/commands/show.rs
+++ b/src/bin/cobl/commands/show.rs
@@ -1,7 +1,14 @@
 use std::{env::set_current_dir, path::PathBuf, sync::Arc};
 
 use cobble::{
-    calc_artifacts::calculate_artifacts, config::{get_workspace_config, parse_cli_vars, TaskOutputCondition, WorkspaceConfigArgs}, dependency::resolve_calculated_dependencies_in_subtrees, execute::execute::TaskExecutor, load::load_projects, task_selection::compute_selected_tasks, util::process_io::StandardIO, workspace::create_workspace
+    calc_artifacts::calculate_artifacts,
+    config::{get_workspace_config, parse_cli_vars, TaskOutputCondition, WorkspaceConfigArgs},
+    dependency::resolve_calculated_dependencies_in_subtrees,
+    execute::execute::TaskExecutor,
+    load::load_projects,
+    task_selection::compute_selected_tasks,
+    util::process_io::StandardIO,
+    workspace::create_workspace,
 };
 
 use crate::commands::run::run_init_task_if_defined;
@@ -36,7 +43,6 @@ pub fn show_task_command(input: ShowTaskInput) -> anyhow::Result<()> {
     let config = Arc::new(get_workspace_config(cwd.as_path(), &ws_config_args)?);
 
     run_init_task_if_defined(&cwd, &config)?;
-
 
     set_current_dir(&config.workspace_dir)
         .expect("found the workspace directory, so we should be able to set that as the cwd");
@@ -73,7 +79,7 @@ pub fn show_task_command(input: ShowTaskInput) -> anyhow::Result<()> {
         selected_tasks.iter(),
         &mut workspace,
         &mut executor,
-        &StandardIO
+        &StandardIO,
     )?;
 
     for task_name in selected_tasks.iter() {

--- a/src/bin/cobl/commands/show.rs
+++ b/src/bin/cobl/commands/show.rs
@@ -2,13 +2,15 @@ use std::{env::set_current_dir, path::PathBuf, sync::Arc};
 
 use cobble::{
     calc_artifacts::calculate_artifacts,
-    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs},
+    config::{get_workspace_config, parse_cli_vars, TaskOutputCondition, WorkspaceConfigArgs},
     dependency::resolve_calculated_dependencies_in_subtrees,
     execute::execute::TaskExecutor,
     load::load_projects,
     task_selection::compute_selected_tasks,
     workspace::create_workspace,
 };
+
+use crate::commands::run::run_init_task_if_defined;
 
 const TAB: &str = "  ";
 
@@ -27,8 +29,10 @@ pub fn show_task_command(input: ShowTaskInput) -> anyhow::Result<()> {
         num_threads,
     } = input;
 
+    let parsed_vars = parse_cli_vars(vars.iter())?;
+
     let ws_config_args = WorkspaceConfigArgs {
-        vars,
+        vars: parsed_vars,
         num_threads: num_threads,
         show_stdout: Some(TaskOutputCondition::Never),
         show_stderr: Some(TaskOutputCondition::Never),
@@ -36,6 +40,10 @@ pub fn show_task_command(input: ShowTaskInput) -> anyhow::Result<()> {
     };
 
     let config = Arc::new(get_workspace_config(cwd.as_path(), &ws_config_args)?);
+
+    run_init_task_if_defined(&cwd, &config)?;
+
+
     set_current_dir(&config.workspace_dir)
         .expect("found the workspace directory, so we should be able to set that as the cwd");
 

--- a/src/bin/cobl/commands/tool.rs
+++ b/src/bin/cobl/commands/tool.rs
@@ -6,10 +6,7 @@
 use std::{env::set_current_dir, path::PathBuf, sync::Arc};
 
 use cobble::{
-    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs},
-    execute::execute::TaskExecutor,
-    load::load_projects,
-    workspace::create_workspace,
+    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs}, execute::execute::TaskExecutor, load::load_projects, util::process_io::{ProcessIO, StandardIO}, workspace::create_workspace
 };
 
 use crate::commands::run::run_init_task_if_defined;
@@ -58,7 +55,8 @@ pub fn check_tool_command(input: CheckToolInput) -> anyhow::Result<()> {
         config.workspace_dir.join(".cobble.db").as_path(),
     )?;
 
-    executor.check_tools(&workspace, selected_tools.iter())?;
+    let standard_io = StandardIO;
+    executor.check_tools(&workspace, selected_tools.iter(), standard_io.out(), standard_io.err())?;
 
     Ok(())
 }

--- a/src/bin/cobl/commands/tool.rs
+++ b/src/bin/cobl/commands/tool.rs
@@ -6,7 +6,11 @@
 use std::{env::set_current_dir, path::PathBuf, sync::Arc};
 
 use cobble::{
-    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs}, execute::execute::TaskExecutor, load::load_projects, util::process_io::StandardIO, workspace::create_workspace
+    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs},
+    execute::execute::TaskExecutor,
+    load::load_projects,
+    util::process_io::StandardIO,
+    workspace::create_workspace,
 };
 
 use crate::commands::run::run_init_task_if_defined;

--- a/src/bin/cobl/commands/tool.rs
+++ b/src/bin/cobl/commands/tool.rs
@@ -6,7 +6,7 @@
 use std::{env::set_current_dir, path::PathBuf, sync::Arc};
 
 use cobble::{
-    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs}, execute::execute::TaskExecutor, load::load_projects, util::process_io::{ProcessIO, StandardIO}, workspace::create_workspace
+    config::{get_workspace_config, TaskOutputCondition, WorkspaceConfigArgs}, execute::execute::TaskExecutor, load::load_projects, util::process_io::StandardIO, workspace::create_workspace
 };
 
 use crate::commands::run::run_init_task_if_defined;
@@ -55,8 +55,7 @@ pub fn check_tool_command(input: CheckToolInput) -> anyhow::Result<()> {
         config.workspace_dir.join(".cobble.db").as_path(),
     )?;
 
-    let standard_io = StandardIO;
-    executor.check_tools(&workspace, selected_tools.iter(), standard_io.out(), standard_io.err())?;
+    executor.check_tools(&workspace, selected_tools.iter(), &StandardIO)?;
 
     Ok(())
 }

--- a/src/bin/cobl/commands/tool.rs
+++ b/src/bin/cobl/commands/tool.rs
@@ -12,6 +12,8 @@ use cobble::{
     workspace::create_workspace,
 };
 
+use crate::commands::run::run_init_task_if_defined;
+
 pub struct CheckToolInput {
     pub cwd: PathBuf,
     pub tools: Vec<String>,
@@ -36,6 +38,9 @@ pub fn check_tool_command(input: CheckToolInput) -> anyhow::Result<()> {
         ..Default::default()
     };
     let config = Arc::new(get_workspace_config(cwd.as_path(), &ws_config_args)?);
+
+    run_init_task_if_defined(&cwd, &config)?;
+
     set_current_dir(&config.workspace_dir)
         .expect("found the workspace directory, so we should be able to set that as the cwd");
 

--- a/src/calc_artifacts.rs
+++ b/src/calc_artifacts.rs
@@ -3,7 +3,7 @@
 //
 // This program is licensed under the GPLv3.0 license (https://github.com/jdarais/cobble/blob/main/COPYING)
 
-use std::{borrow::Cow, collections::HashMap, error::Error, fmt, io, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, error::Error, fmt, sync::Arc};
 
 use crate::{
     dependency::{resolve_calculated_dependencies_in_subtrees, ExecutionGraphError}, execute::execute::{TaskExecutionError, TaskExecutor}, project_def::{artifact::ArtifactsRecord, Artifacts}, resolve::{resolve_names_in_artifacts, NameResolutionError}, util::process_io::ProcessIO, workspace::{Task, Workspace}
@@ -48,7 +48,7 @@ fn combine_artifacts(lhs: &Artifacts, rhs: &Artifacts) -> Artifacts {
 pub fn calculate_artifacts<IO: ProcessIO>(
     workspace: &mut Workspace,
     executor: &mut TaskExecutor,
-    io: &IO
+    pio: &IO
 ) -> Result<(), CalcArtifactsError> {
     let mut calc_artifacts_tasks: Vec<Arc<str>> = Vec::new();
 
@@ -59,12 +59,12 @@ pub fn calculate_artifacts<IO: ProcessIO>(
     }
 
     // First need to make sure all calculated dependencies in the dependency trees of the calc artifacts tasks are resolved
-    resolve_calculated_dependencies_in_subtrees(calc_artifacts_tasks.iter(), workspace, executor, io)
+    resolve_calculated_dependencies_in_subtrees(calc_artifacts_tasks.iter(), workspace, executor, pio)
         .map_err(|e| CalcArtifactsError::DependencyError(e))?;
 
     // Execute the tasks
     executor
-        .execute_tasks(&workspace, calc_artifacts_tasks.iter(), io.out(), io.err())
+        .execute_tasks(&workspace, calc_artifacts_tasks.iter(), pio)
         .map_err(|e| CalcArtifactsError::ExecutionError(e))?;
 
     // Swap the calc artifacts for the task outputs of that task

--- a/src/calc_artifacts.rs
+++ b/src/calc_artifacts.rs
@@ -3,10 +3,10 @@
 //
 // This program is licensed under the GPLv3.0 license (https://github.com/jdarais/cobble/blob/main/COPYING)
 
-use std::{borrow::Cow, collections::HashMap, error::Error, fmt, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, error::Error, fmt, io, sync::Arc};
 
 use crate::{
-    dependency::{resolve_calculated_dependencies_in_subtrees, ExecutionGraphError}, execute::execute::{TaskExecutionError, TaskExecutor}, project_def::{artifact::ArtifactsRecord, Artifacts}, resolve::{resolve_names_in_artifacts, NameResolutionError}, workspace::{Task, Workspace}
+    dependency::{resolve_calculated_dependencies_in_subtrees, ExecutionGraphError}, execute::execute::{TaskExecutionError, TaskExecutor}, project_def::{artifact::ArtifactsRecord, Artifacts}, resolve::{resolve_names_in_artifacts, NameResolutionError}, util::process_io::ProcessIO, workspace::{Task, Workspace}
 };
 
 #[derive(Debug)]
@@ -45,9 +45,10 @@ fn combine_artifacts(lhs: &Artifacts, rhs: &Artifacts) -> Artifacts {
     }
 }
 
-pub fn calculate_artifacts(
+pub fn calculate_artifacts<IO: ProcessIO>(
     workspace: &mut Workspace,
     executor: &mut TaskExecutor,
+    io: &IO
 ) -> Result<(), CalcArtifactsError> {
     let mut calc_artifacts_tasks: Vec<Arc<str>> = Vec::new();
 
@@ -58,12 +59,12 @@ pub fn calculate_artifacts(
     }
 
     // First need to make sure all calculated dependencies in the dependency trees of the calc artifacts tasks are resolved
-    resolve_calculated_dependencies_in_subtrees(calc_artifacts_tasks.iter(), workspace, executor)
+    resolve_calculated_dependencies_in_subtrees(calc_artifacts_tasks.iter(), workspace, executor, io)
         .map_err(|e| CalcArtifactsError::DependencyError(e))?;
 
     // Execute the tasks
     executor
-        .execute_tasks(&workspace, calc_artifacts_tasks.iter())
+        .execute_tasks(&workspace, calc_artifacts_tasks.iter(), io.out(), io.err())
         .map_err(|e| CalcArtifactsError::ExecutionError(e))?;
 
     // Swap the calc artifacts for the task outputs of that task

--- a/src/calc_artifacts.rs
+++ b/src/calc_artifacts.rs
@@ -6,7 +6,12 @@
 use std::{borrow::Cow, collections::HashMap, error::Error, fmt, sync::Arc};
 
 use crate::{
-    dependency::{resolve_calculated_dependencies_in_subtrees, ExecutionGraphError}, execute::execute::{TaskExecutionError, TaskExecutor}, project_def::{artifact::ArtifactsRecord, Artifacts}, resolve::{resolve_names_in_artifacts, NameResolutionError}, util::process_io::ProcessIO, workspace::{Task, Workspace}
+    dependency::{resolve_calculated_dependencies_in_subtrees, ExecutionGraphError},
+    execute::execute::{TaskExecutionError, TaskExecutor},
+    project_def::{artifact::ArtifactsRecord, Artifacts},
+    resolve::{resolve_names_in_artifacts, NameResolutionError},
+    util::process_io::ProcessIO,
+    workspace::{Task, Workspace},
 };
 
 #[derive(Debug)]
@@ -48,7 +53,7 @@ fn combine_artifacts(lhs: &Artifacts, rhs: &Artifacts) -> Artifacts {
 pub fn calculate_artifacts<IO: ProcessIO>(
     workspace: &mut Workspace,
     executor: &mut TaskExecutor,
-    pio: &IO
+    pio: &IO,
 ) -> Result<(), CalcArtifactsError> {
     let mut calc_artifacts_tasks: Vec<Arc<str>> = Vec::new();
 
@@ -59,8 +64,13 @@ pub fn calculate_artifacts<IO: ProcessIO>(
     }
 
     // First need to make sure all calculated dependencies in the dependency trees of the calc artifacts tasks are resolved
-    resolve_calculated_dependencies_in_subtrees(calc_artifacts_tasks.iter(), workspace, executor, pio)
-        .map_err(|e| CalcArtifactsError::DependencyError(e))?;
+    resolve_calculated_dependencies_in_subtrees(
+        calc_artifacts_tasks.iter(),
+        workspace,
+        executor,
+        pio,
+    )
+    .map_err(|e| CalcArtifactsError::DependencyError(e))?;
 
     // Execute the tasks
     executor
@@ -83,14 +93,20 @@ pub fn calculate_artifacts<IO: ProcessIO>(
                     }
                 })?;
             let mut task_output_artifacts: Artifacts = task_output_record.into();
-            resolve_names_in_artifacts(&task.project_name, &task.project_path, &mut task_output_artifacts).map_err(|e| {
-                CalcArtifactsError::NameResolutionError {
-                    task_name: task.name.clone(),
-                    error: e,
-                }
+            resolve_names_in_artifacts(
+                &task.project_name,
+                &task.project_path,
+                &mut task_output_artifacts,
+            )
+            .map_err(|e| CalcArtifactsError::NameResolutionError {
+                task_name: task.name.clone(),
+                error: e,
             })?;
 
-            artifacts = Cow::Owned(combine_artifacts(artifacts.as_ref(), &task_output_artifacts));
+            artifacts = Cow::Owned(combine_artifacts(
+                artifacts.as_ref(),
+                &task_output_artifacts,
+            ));
         }
 
         let mut new_task = Task::clone(task);

--- a/src/config.rs
+++ b/src/config.rs
@@ -197,7 +197,7 @@ pub fn parse_workspace_config(
                             "init config variable missing 'workspace' property",
                         ))
                     })?;
-                let workspace_dir_str: String = workspace_dir_val.try_into().map_err(|e| {
+                let workspace_dir_str: String = workspace_dir_val.try_into().map_err(|_| {
                     WorkspaceConfigError::ValueError(String::from(
                         "init.workspace must be a string",
                     ))
@@ -208,7 +208,7 @@ pub fn parse_workspace_config(
                         "init config variable missing 'task' property",
                     ))
                 })?;
-                let task_str: String = task_val.try_into().map_err(|e| {
+                let task_str: String = task_val.try_into().map_err(|_| {
                     WorkspaceConfigError::ValueError(String::from("init.task must be a string"))
                 })?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,13 @@ pub const PROJECT_FILE_NAME: &str = "project.lua";
 pub const DEFAULT_NUM_THREADS: u8 = 5;
 
 #[derive(Debug)]
+pub struct WorkspaceInit {
+    pub workspace_dir: PathBuf,
+    pub task: String,
+    pub cwd: Option<PathBuf>
+}
+
+#[derive(Debug)]
 pub struct WorkspaceConfig {
     pub workspace_dir: PathBuf,
     pub root_projects: Vec<String>,
@@ -27,6 +34,7 @@ pub struct WorkspaceConfig {
     pub num_threads: u8,
     pub show_stdout: TaskOutputCondition,
     pub show_stderr: TaskOutputCondition,
+    pub init: Option<WorkspaceInit>
 }
 
 #[derive(Default)]
@@ -177,6 +185,39 @@ pub fn parse_workspace_config(
         vars.insert(k, v.into());
     }
 
+    let init_toml_opt: Option<toml::Value> = config.remove("init");
+    let init: Option<WorkspaceInit> = match init_toml_opt {
+        None => None,
+        Some(v) => match v {
+            toml::Value::Table(t) => {
+                let workspace_dir_val: toml::Value = t.get("workspace_dir")
+                    .cloned()
+                    .ok_or_else(|| WorkspaceConfigError::ValueError(String::from("init config variable missing 'workspace_dir' property")))?;
+                let workspace_dir_str: String = workspace_dir_val.try_into().map_err(|e| WorkspaceConfigError::ValueError(String::from("init.workspace_dir must be a string")))?;
+
+                let task_val: toml::Value = t.get("task")
+                    .cloned()
+                    .ok_or_else(|| WorkspaceConfigError::ValueError(String::from("init config variable missing 'task' property")))?;
+                let task_str: String = task_val.try_into().map_err(|e| WorkspaceConfigError::ValueError(String::from("init.task must be a string")))?;
+
+                let cwd_val_opt: Option<toml::Value> = t.get("task").cloned();
+                let cwd_str_opt: Option<String> = match cwd_val_opt {
+                    None => None,
+                    Some(cwd_val) => cwd_val.try_into().map_err(|e| WorkspaceConfigError::ValueError(String::from("init.task must be a string")))?
+                };
+
+                Some(WorkspaceInit {
+                    workspace_dir: PathBuf::from(workspace_dir_str),
+                    task: task_str,
+                    cwd: cwd_str_opt.map(|v| PathBuf::from(v))
+                })
+            },
+            _ => {
+                return Err(WorkspaceConfigError::ValueError(String::from("init config variable must be a table")));
+            }
+        }
+    };
+
     // Raise an error if there are unrecognized keys in the config table
     if let Some((key, _)) = config.iter().next() {
         return Err(WorkspaceConfigError::ValueError(format!(
@@ -184,6 +225,7 @@ pub fn parse_workspace_config(
             key
         )));
     }
+
 
     Ok(WorkspaceConfig {
         workspace_dir: PathBuf::from(config_path.parent().unwrap_or_else(|| Path::new("."))),
@@ -193,6 +235,7 @@ pub fn parse_workspace_config(
         num_threads,
         show_stdout: stdout,
         show_stderr: stderr,
+        init
     })
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,8 @@ pub const DEFAULT_NUM_THREADS: u8 = 5;
 pub struct WorkspaceInit {
     pub workspace_dir: PathBuf,
     pub task: String,
-    pub cwd: Option<PathBuf>
+    pub show_stdout: TaskOutputCondition,
+    pub show_stderr: TaskOutputCondition
 }
 
 #[derive(Debug)]
@@ -34,12 +35,12 @@ pub struct WorkspaceConfig {
     pub num_threads: u8,
     pub show_stdout: TaskOutputCondition,
     pub show_stderr: TaskOutputCondition,
-    pub init: Option<WorkspaceInit>
+    pub init: Option<WorkspaceInit>,
 }
 
 #[derive(Default)]
 pub struct WorkspaceConfigArgs {
-    pub vars: Vec<String>,
+    pub vars: HashMap<String, TaskVar>,
     pub force_run_tasks: Option<bool>,
     pub num_threads: Option<u8>,
     pub show_stdout: Option<TaskOutputCondition>,
@@ -190,32 +191,60 @@ pub fn parse_workspace_config(
         None => None,
         Some(v) => match v {
             toml::Value::Table(t) => {
-                let workspace_dir_val: toml::Value = t.get("workspace_dir")
-                    .cloned()
-                    .ok_or_else(|| WorkspaceConfigError::ValueError(String::from("init config variable missing 'workspace_dir' property")))?;
-                let workspace_dir_str: String = workspace_dir_val.try_into().map_err(|e| WorkspaceConfigError::ValueError(String::from("init.workspace_dir must be a string")))?;
+                let workspace_dir_val: toml::Value =
+                    t.get("workspace").cloned().ok_or_else(|| {
+                        WorkspaceConfigError::ValueError(String::from(
+                            "init config variable missing 'workspace' property",
+                        ))
+                    })?;
+                let workspace_dir_str: String = workspace_dir_val.try_into().map_err(|e| {
+                    WorkspaceConfigError::ValueError(String::from(
+                        "init.workspace must be a string",
+                    ))
+                })?;
 
-                let task_val: toml::Value = t.get("task")
-                    .cloned()
-                    .ok_or_else(|| WorkspaceConfigError::ValueError(String::from("init config variable missing 'task' property")))?;
-                let task_str: String = task_val.try_into().map_err(|e| WorkspaceConfigError::ValueError(String::from("init.task must be a string")))?;
+                let task_val: toml::Value = t.get("task").cloned().ok_or_else(|| {
+                    WorkspaceConfigError::ValueError(String::from(
+                        "init config variable missing 'task' property",
+                    ))
+                })?;
+                let task_str: String = task_val.try_into().map_err(|e| {
+                    WorkspaceConfigError::ValueError(String::from("init.task must be a string"))
+                })?;
 
-                let cwd_val_opt: Option<toml::Value> = t.get("task").cloned();
-                let cwd_str_opt: Option<String> = match cwd_val_opt {
-                    None => None,
-                    Some(cwd_val) => cwd_val.try_into().map_err(|e| WorkspaceConfigError::ValueError(String::from("init.task must be a string")))?
+                let init_stdout_opt: Option<toml::Value> = t.get("stdout").cloned();
+                let init_stdout_enum: Option<TaskOutputCondition> = match init_stdout_opt {
+                    Some(show_stdout) => {
+                        let show_stdout_str: String = show_stdout.try_into().map_err(|e| WorkspaceConfigError::ValueError(format!("at 'init.stdout': {}", e)))?;
+                        let show_stdout_enum: TaskOutputCondition = parse_output_condition(&show_stdout_str).map_err(|e| WorkspaceConfigError::ValueError(format!("at 'init.stdout': {}", e)))?;
+                        Some(show_stdout_enum)
+                    },
+                    None => None
+                };
+
+                let init_stderr_opt: Option<toml::Value> = t.get("stderr").cloned();
+                let init_stderr_enum: Option<TaskOutputCondition> = match init_stderr_opt {
+                    Some(show_stdout) => {
+                        let show_stderr_str: String = show_stdout.try_into().map_err(|e| WorkspaceConfigError::ValueError(format!("at 'init.stderr': {}", e)))?;
+                        let show_stderr_enum: TaskOutputCondition = parse_output_condition(&show_stderr_str).map_err(|e| WorkspaceConfigError::ValueError(format!("at 'init.stdout': {}", e)))?;
+                        Some(show_stderr_enum)
+                    },
+                    None => None
                 };
 
                 Some(WorkspaceInit {
                     workspace_dir: PathBuf::from(workspace_dir_str),
                     task: task_str,
-                    cwd: cwd_str_opt.map(|v| PathBuf::from(v))
+                    show_stdout: init_stdout_enum.unwrap_or(TaskOutputCondition::OnFail),
+                    show_stderr: init_stderr_enum.unwrap_or(TaskOutputCondition::OnFail)
                 })
-            },
-            _ => {
-                return Err(WorkspaceConfigError::ValueError(String::from("init config variable must be a table")));
             }
-        }
+            _ => {
+                return Err(WorkspaceConfigError::ValueError(String::from(
+                    "init config variable must be a table",
+                )));
+            }
+        },
     };
 
     // Raise an error if there are unrecognized keys in the config table
@@ -226,7 +255,6 @@ pub fn parse_workspace_config(
         )));
     }
 
-
     Ok(WorkspaceConfig {
         workspace_dir: PathBuf::from(config_path.parent().unwrap_or_else(|| Path::new("."))),
         root_projects,
@@ -235,7 +263,7 @@ pub fn parse_workspace_config(
         num_threads,
         show_stdout: stdout,
         show_stderr: stderr,
-        init
+        init,
     })
 }
 
@@ -323,19 +351,20 @@ pub fn get_workspace_config(
         config.show_stderr = show_stderr.clone();
     }
 
-    add_cli_vars_to_workspace_config(args.vars.iter().map(String::as_str), &mut config)?;
+    add_cli_vars_to_workspace_config(args.vars.iter(), &mut config)?;
 
     Ok(config)
 }
 
-fn add_cli_vars_to_workspace_config<'a, I>(
-    vars: I,
-    config: &mut WorkspaceConfig,
-) -> Result<(), WorkspaceConfigError>
+pub fn parse_cli_vars<I, S>(vars: I) -> Result<HashMap<String, TaskVar>, WorkspaceConfigError>
 where
-    I: Iterator<Item = &'a str>,
+    I: Iterator<Item = S>,
+    S: AsRef<str>,
 {
-    for var in vars {
+    let mut parsed_vars: HashMap<String, TaskVar> = HashMap::new();
+
+    for var_s in vars {
+        let var = var_s.as_ref();
         let eq_idx = match var.find("=") {
             Some(i) => i,
             None => {
@@ -348,12 +377,25 @@ where
         let var_name = &var[..eq_idx];
         let var_val = &var[eq_idx + 1..];
 
-        set_var(
-            var_name,
-            TaskVar::String(var_val.to_owned()),
-            &mut config.vars,
-        )
-        .map_err(|e| WorkspaceConfigError::SetVarError(e))?;
+        parsed_vars.insert(var_name.to_owned(), TaskVar::String(var_val.to_owned()));
+    }
+
+    Ok(parsed_vars)
+}
+
+fn add_cli_vars_to_workspace_config<'a, I, S>(
+    vars: I,
+    config: &mut WorkspaceConfig,
+) -> Result<(), WorkspaceConfigError>
+where
+    I: Iterator<Item = (&'a S, &'a TaskVar)>,
+    S: AsRef<str> + 'a,
+{
+    for (var_name_s, var_val) in vars {
+        let var_name = var_name_s.as_ref();
+
+        set_var(var_name, var_val.clone(), &mut config.vars)
+            .map_err(|e| WorkspaceConfigError::SetVarError(e))?;
     }
 
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,11 +72,11 @@ impl Display for WorkspaceConfigError {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TaskOutputCondition {
-    Always,
-    Never,
-    OnFail,
+    Always = 2,
+    OnFail = 1,
+    Never = 0,
 }
 
 impl<'lua> mlua::FromLua<'lua> for TaskOutputCondition {
@@ -212,6 +212,21 @@ pub fn parse_workspace_config(
                     WorkspaceConfigError::ValueError(String::from("init.task must be a string"))
                 })?;
 
+                let init_output_opt: Option<toml::Value> = t.get("output").cloned();
+                let init_output_enum: Option<TaskOutputCondition> = match init_output_opt {
+                    Some(show_stdout) => {
+                        let show_stdout_str: String = show_stdout.try_into().map_err(|e| {
+                            WorkspaceConfigError::ValueError(format!("at 'init.output': {}", e))
+                        })?;
+                        let show_stdout_enum: TaskOutputCondition =
+                            parse_output_condition(&show_stdout_str).map_err(|e| {
+                                WorkspaceConfigError::ValueError(format!("at 'init.output': {}", e))
+                            })?;
+                        Some(show_stdout_enum)
+                    }
+                    None => None,
+                };
+
                 let init_stdout_opt: Option<toml::Value> = t.get("stdout").cloned();
                 let init_stdout_enum: Option<TaskOutputCondition> = match init_stdout_opt {
                     Some(show_stdout) => {
@@ -245,8 +260,12 @@ pub fn parse_workspace_config(
                 Some(WorkspaceInit {
                     workspace_dir: PathBuf::from(workspace_dir_str),
                     task: task_str,
-                    show_stdout: init_stdout_enum.unwrap_or(TaskOutputCondition::OnFail),
-                    show_stderr: init_stderr_enum.unwrap_or(TaskOutputCondition::OnFail),
+                    show_stdout: init_stdout_enum
+                        .or(init_output_enum.clone())
+                        .unwrap_or(TaskOutputCondition::OnFail),
+                    show_stderr: init_stderr_enum
+                        .or(init_output_enum)
+                        .unwrap_or(TaskOutputCondition::OnFail),
                 })
             }
             _ => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ pub struct WorkspaceInit {
     pub workspace_dir: PathBuf,
     pub task: String,
     pub show_stdout: TaskOutputCondition,
-    pub show_stderr: TaskOutputCondition
+    pub show_stderr: TaskOutputCondition,
 }
 
 #[derive(Debug)]
@@ -215,28 +215,38 @@ pub fn parse_workspace_config(
                 let init_stdout_opt: Option<toml::Value> = t.get("stdout").cloned();
                 let init_stdout_enum: Option<TaskOutputCondition> = match init_stdout_opt {
                     Some(show_stdout) => {
-                        let show_stdout_str: String = show_stdout.try_into().map_err(|e| WorkspaceConfigError::ValueError(format!("at 'init.stdout': {}", e)))?;
-                        let show_stdout_enum: TaskOutputCondition = parse_output_condition(&show_stdout_str).map_err(|e| WorkspaceConfigError::ValueError(format!("at 'init.stdout': {}", e)))?;
+                        let show_stdout_str: String = show_stdout.try_into().map_err(|e| {
+                            WorkspaceConfigError::ValueError(format!("at 'init.stdout': {}", e))
+                        })?;
+                        let show_stdout_enum: TaskOutputCondition =
+                            parse_output_condition(&show_stdout_str).map_err(|e| {
+                                WorkspaceConfigError::ValueError(format!("at 'init.stdout': {}", e))
+                            })?;
                         Some(show_stdout_enum)
-                    },
-                    None => None
+                    }
+                    None => None,
                 };
 
                 let init_stderr_opt: Option<toml::Value> = t.get("stderr").cloned();
                 let init_stderr_enum: Option<TaskOutputCondition> = match init_stderr_opt {
                     Some(show_stdout) => {
-                        let show_stderr_str: String = show_stdout.try_into().map_err(|e| WorkspaceConfigError::ValueError(format!("at 'init.stderr': {}", e)))?;
-                        let show_stderr_enum: TaskOutputCondition = parse_output_condition(&show_stderr_str).map_err(|e| WorkspaceConfigError::ValueError(format!("at 'init.stdout': {}", e)))?;
+                        let show_stderr_str: String = show_stdout.try_into().map_err(|e| {
+                            WorkspaceConfigError::ValueError(format!("at 'init.stderr': {}", e))
+                        })?;
+                        let show_stderr_enum: TaskOutputCondition =
+                            parse_output_condition(&show_stderr_str).map_err(|e| {
+                                WorkspaceConfigError::ValueError(format!("at 'init.stdout': {}", e))
+                            })?;
                         Some(show_stderr_enum)
-                    },
-                    None => None
+                    }
+                    None => None,
                 };
 
                 Some(WorkspaceInit {
                     workspace_dir: PathBuf::from(workspace_dir_str),
                     task: task_str,
                     show_stdout: init_stdout_enum.unwrap_or(TaskOutputCondition::OnFail),
-                    show_stderr: init_stderr_enum.unwrap_or(TaskOutputCondition::OnFail)
+                    show_stderr: init_stderr_enum.unwrap_or(TaskOutputCondition::OnFail),
                 })
             }
             _ => {

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -13,6 +13,7 @@ use crate::execute::execute::{TaskExecutionError, TaskExecutor};
 use crate::project_def::dependency::Dependencies;
 use crate::project_def::{DependencyListByType, Project};
 use crate::resolve::{resolve_names_in_dependency_list, NameResolutionError};
+use crate::util::process_io::ProcessIO;
 use crate::workspace::{add_dependency_list_to_task, Task, Workspace};
 
 #[derive(Debug)]
@@ -73,26 +74,29 @@ where
     file_providers
 }
 
-pub fn resolve_calculated_dependencies_in_subtrees<'a, T>(
+pub fn resolve_calculated_dependencies_in_subtrees<'a, T, IO>(
     task_names: T,
     workspace: &mut Workspace,
     task_executor: &mut TaskExecutor,
+    pio: &IO
 ) -> Result<(), ExecutionGraphError>
 where
     T: Iterator<Item = &'a Arc<str>>,
+    IO: ProcessIO
 {
     for task_name in task_names {
         // TODO: Track the names of tasks that have get visited with each invocation so we can skip
         // them if they show up in another subtree
-        resolve_calculated_dependencies_in_subtree(task_name, workspace, task_executor)?;
+        resolve_calculated_dependencies_in_subtree(task_name, workspace, task_executor, pio)?;
     }
     Ok(())
 }
 
-pub fn resolve_calculated_dependencies_in_subtree(
+pub fn resolve_calculated_dependencies_in_subtree<IO: ProcessIO>(
     task_name: &Arc<str>,
     workspace: &mut Workspace,
     task_executor: &mut TaskExecutor,
+    pio: &IO
 ) -> Result<(), ExecutionGraphError> {
     let mut changed = true;
     while changed {
@@ -101,16 +105,18 @@ pub fn resolve_calculated_dependencies_in_subtree(
             workspace,
             &mut HashSet::new(),
             task_executor,
+            pio
         )?;
     }
     Ok(())
 }
 
-fn resolve_calculated_dependencies_in_subtree_once_with_history(
+fn resolve_calculated_dependencies_in_subtree_once_with_history<IO: ProcessIO>(
     task_name: &Arc<str>,
     workspace: &mut Workspace,
     visited: &mut HashSet<Arc<str>>,
     task_executor: &mut TaskExecutor,
+    pio: &IO
 ) -> Result<bool, ExecutionGraphError> {
     if visited.contains(task_name) {
         return Err(ExecutionGraphError::CycleError(task_name.clone()));
@@ -134,10 +140,11 @@ fn resolve_calculated_dependencies_in_subtree_once_with_history(
             workspace,
             visited,
             task_executor,
+            pio
         )?;
 
         task_executor
-            .execute_tasks(workspace, Some(calc_dep.clone()).iter())
+            .execute_tasks(workspace, Some(calc_dep.clone()).iter(), pio.out(), pio.err())
             .map_err(|e| ExecutionGraphError::TaskExecutionError(e))?;
 
         let executor_cache = task_executor.cache();
@@ -182,6 +189,7 @@ fn resolve_calculated_dependencies_in_subtree_once_with_history(
                 workspace,
                 visited,
                 task_executor,
+                pio
             )?;
     }
 
@@ -193,6 +201,7 @@ fn resolve_calculated_dependencies_in_subtree_once_with_history(
                     workspace,
                     visited,
                     task_executor,
+                    pio
                 )?;
         }
     }
@@ -211,6 +220,7 @@ fn resolve_calculated_dependencies_in_subtree_once_with_history(
                     workspace,
                     visited,
                     task_executor,
+                    pio
                 )?;
         }
     }

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -144,7 +144,7 @@ fn resolve_calculated_dependencies_in_subtree_once_with_history<IO: ProcessIO>(
         )?;
 
         task_executor
-            .execute_tasks(workspace, Some(calc_dep.clone()).iter(), pio.out(), pio.err())
+            .execute_tasks(workspace, Some(calc_dep.clone()).iter(), pio)
             .map_err(|e| ExecutionGraphError::TaskExecutionError(e))?;
 
         let executor_cache = task_executor.cache();

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -78,11 +78,11 @@ pub fn resolve_calculated_dependencies_in_subtrees<'a, T, IO>(
     task_names: T,
     workspace: &mut Workspace,
     task_executor: &mut TaskExecutor,
-    pio: &IO
+    pio: &IO,
 ) -> Result<(), ExecutionGraphError>
 where
     T: Iterator<Item = &'a Arc<str>>,
-    IO: ProcessIO
+    IO: ProcessIO,
 {
     for task_name in task_names {
         // TODO: Track the names of tasks that have get visited with each invocation so we can skip
@@ -96,7 +96,7 @@ pub fn resolve_calculated_dependencies_in_subtree<IO: ProcessIO>(
     task_name: &Arc<str>,
     workspace: &mut Workspace,
     task_executor: &mut TaskExecutor,
-    pio: &IO
+    pio: &IO,
 ) -> Result<(), ExecutionGraphError> {
     let mut changed = true;
     while changed {
@@ -105,7 +105,7 @@ pub fn resolve_calculated_dependencies_in_subtree<IO: ProcessIO>(
             workspace,
             &mut HashSet::new(),
             task_executor,
-            pio
+            pio,
         )?;
     }
     Ok(())
@@ -116,7 +116,7 @@ fn resolve_calculated_dependencies_in_subtree_once_with_history<IO: ProcessIO>(
     workspace: &mut Workspace,
     visited: &mut HashSet<Arc<str>>,
     task_executor: &mut TaskExecutor,
-    pio: &IO
+    pio: &IO,
 ) -> Result<bool, ExecutionGraphError> {
     if visited.contains(task_name) {
         return Err(ExecutionGraphError::CycleError(task_name.clone()));
@@ -140,7 +140,7 @@ fn resolve_calculated_dependencies_in_subtree_once_with_history<IO: ProcessIO>(
             workspace,
             visited,
             task_executor,
-            pio
+            pio,
         )?;
 
         task_executor
@@ -189,7 +189,7 @@ fn resolve_calculated_dependencies_in_subtree_once_with_history<IO: ProcessIO>(
                 workspace,
                 visited,
                 task_executor,
-                pio
+                pio,
             )?;
     }
 
@@ -201,7 +201,7 @@ fn resolve_calculated_dependencies_in_subtree_once_with_history<IO: ProcessIO>(
                     workspace,
                     visited,
                     task_executor,
-                    pio
+                    pio,
                 )?;
         }
     }
@@ -220,7 +220,7 @@ fn resolve_calculated_dependencies_in_subtree_once_with_history<IO: ProcessIO>(
                     workspace,
                     visited,
                     task_executor,
-                    pio
+                    pio,
                 )?;
         }
     }

--- a/src/execute/execute.rs
+++ b/src/execute/execute.rs
@@ -18,6 +18,7 @@ use crate::db::{new_db_env, DeleteError, GetError, PutError};
 use crate::execute::job_io::ConcurrentIO;
 use crate::execute::worker::{run_task_executor_worker, TaskExecutorWorkerArgs};
 use crate::project_def::ExternalTool;
+use crate::util::process_io::ProcessIO;
 use crate::vars::VarLookupError;
 use crate::workspace::{BuildEnv, Task, TaskType, Workspace};
 
@@ -557,17 +558,15 @@ impl TaskExecutor {
         }
     }
 
-    pub fn check_tools<'a, T, OW, EW>(
+    pub fn check_tools<'a, T, IO>(
         &mut self,
         workspace: &Workspace,
         tools: T,
-        out: OW,
-        err: EW
+        pio: &IO
     ) -> Result<(), TaskExecutionError>
     where
         T: Iterator<Item = &'a Arc<str>>,
-        OW: io::Write,
-        EW: io::Write
+        IO: ProcessIO
     {
         self.ensure_worker_threads();
 
@@ -578,20 +577,18 @@ impl TaskExecutor {
             add_tool_check_jobs(tool, &frozen_workspace, &mut jobs)?;
         }
 
-        self.execute_graph(jobs, &frozen_workspace, out, err)
+        self.execute_graph(jobs, &frozen_workspace, pio)
     }
 
-    pub fn execute_tasks<'a, T, OW, EW>(
+    pub fn execute_tasks<'a, T, IO>(
         &mut self,
         workspace: &Workspace,
         tasks: T,
-        out: OW,
-        err: EW,
+        pio: &IO
     ) -> Result<(), TaskExecutionError>
     where
         T: Iterator<Item = &'a Arc<str>>,
-        OW: io::Write,
-        EW: io::Write
+        IO: ProcessIO
     {
         self.ensure_worker_threads();
 
@@ -602,20 +599,18 @@ impl TaskExecutor {
             add_task_jobs(task, &frozen_workspace, &mut jobs)?;
         }
 
-        self.execute_graph(jobs, &frozen_workspace, out, err)
+        self.execute_graph(jobs, &frozen_workspace, pio)
     }
 
-    pub fn clean_tasks<'a, T, OW, EW>(
+    pub fn clean_tasks<'a, T, IO>(
         &mut self,
         workspace: &Workspace,
         tasks: T,
-        out: OW,
-        err: EW
+        pio: &IO
     ) -> Result<(), TaskExecutionError>
     where
         T: Iterator<Item = &'a Arc<str>>,
-        OW: io::Write,
-        EW: io::Write
+        IO: ProcessIO
     {
         self.ensure_worker_threads();
 
@@ -626,21 +621,19 @@ impl TaskExecutor {
             add_clean_jobs(task, &frozen_workspace, &mut jobs)?;
         }
 
-        self.execute_graph(jobs, &frozen_workspace, out, err)
+        self.execute_graph(jobs, &frozen_workspace, pio)
     }
 
-    pub fn do_env_actions<'a, E, OW, EW>(
+    pub fn do_env_actions<'a, E, IO>(
         &mut self,
         workspace: &Workspace,
         envs: E,
         args: &Vec<Arc<str>>,
-        out: OW,
-        err: EW
+        pio: &IO
     ) -> Result<(), TaskExecutionError>
     where
         E: Iterator<Item = &'a Arc<str>>,
-        OW: io::Write,
-        EW: io::Write
+        IO: ProcessIO
     {
         self.ensure_worker_threads();
 
@@ -651,19 +644,16 @@ impl TaskExecutor {
             add_env_action_jobs(env, args, &frozen_workspace, &mut jobs)?;
         }
 
-        self.execute_graph(jobs, &frozen_workspace, out, err)
+        self.execute_graph(jobs, &frozen_workspace, pio)
     }
 
-    fn execute_graph<OW, EW>(
+    fn execute_graph<IO>(
         &mut self,
         nodes: HashMap<Arc<str>, ExecutorJob>,
         workspace: &Arc<Workspace>,
-        out: OW,
-        err: EW,
+        pio: &IO
     ) -> Result<(), TaskExecutionError>
-    where
-        OW: io::Write,
-        EW: io::Write
+    where IO: ProcessIO
     {
         let dep_edges = &compute_dependency_edges(&nodes, workspace.as_ref())?;
 
@@ -684,7 +674,7 @@ impl TaskExecutor {
 
         let mut in_progress_jobs: HashSet<Arc<str>> = HashSet::new();
         let mut completed_jobs: HashSet<Arc<str>> = HashSet::new();
-        let mut concurrent_io = ConcurrentIO::new(out, err);
+        let mut concurrent_io = ConcurrentIO::new(pio.out(), pio.err());
 
         let mut remaining_jobs = nodes;
 

--- a/src/execute/execute.rs
+++ b/src/execute/execute.rs
@@ -557,13 +557,17 @@ impl TaskExecutor {
         }
     }
 
-    pub fn check_tools<'a, T>(
+    pub fn check_tools<'a, T, OW, EW>(
         &mut self,
         workspace: &Workspace,
         tools: T,
+        out: OW,
+        err: EW
     ) -> Result<(), TaskExecutionError>
     where
         T: Iterator<Item = &'a Arc<str>>,
+        OW: io::Write,
+        EW: io::Write
     {
         self.ensure_worker_threads();
 
@@ -574,16 +578,20 @@ impl TaskExecutor {
             add_tool_check_jobs(tool, &frozen_workspace, &mut jobs)?;
         }
 
-        self.execute_graph(jobs, &frozen_workspace)
+        self.execute_graph(jobs, &frozen_workspace, out, err)
     }
 
-    pub fn execute_tasks<'a, T>(
+    pub fn execute_tasks<'a, T, OW, EW>(
         &mut self,
         workspace: &Workspace,
         tasks: T,
+        out: OW,
+        err: EW,
     ) -> Result<(), TaskExecutionError>
     where
         T: Iterator<Item = &'a Arc<str>>,
+        OW: io::Write,
+        EW: io::Write
     {
         self.ensure_worker_threads();
 
@@ -594,16 +602,20 @@ impl TaskExecutor {
             add_task_jobs(task, &frozen_workspace, &mut jobs)?;
         }
 
-        self.execute_graph(jobs, &frozen_workspace)
+        self.execute_graph(jobs, &frozen_workspace, out, err)
     }
 
-    pub fn clean_tasks<'a, T>(
+    pub fn clean_tasks<'a, T, OW, EW>(
         &mut self,
         workspace: &Workspace,
         tasks: T,
+        out: OW,
+        err: EW
     ) -> Result<(), TaskExecutionError>
     where
         T: Iterator<Item = &'a Arc<str>>,
+        OW: io::Write,
+        EW: io::Write
     {
         self.ensure_worker_threads();
 
@@ -614,17 +626,21 @@ impl TaskExecutor {
             add_clean_jobs(task, &frozen_workspace, &mut jobs)?;
         }
 
-        self.execute_graph(jobs, &frozen_workspace)
+        self.execute_graph(jobs, &frozen_workspace, out, err)
     }
 
-    pub fn do_env_actions<'a, E>(
+    pub fn do_env_actions<'a, E, OW, EW>(
         &mut self,
         workspace: &Workspace,
         envs: E,
         args: &Vec<Arc<str>>,
+        out: OW,
+        err: EW
     ) -> Result<(), TaskExecutionError>
     where
         E: Iterator<Item = &'a Arc<str>>,
+        OW: io::Write,
+        EW: io::Write
     {
         self.ensure_worker_threads();
 
@@ -635,14 +651,20 @@ impl TaskExecutor {
             add_env_action_jobs(env, args, &frozen_workspace, &mut jobs)?;
         }
 
-        self.execute_graph(jobs, &frozen_workspace)
+        self.execute_graph(jobs, &frozen_workspace, out, err)
     }
 
-    fn execute_graph(
+    fn execute_graph<OW, EW>(
         &mut self,
         nodes: HashMap<Arc<str>, ExecutorJob>,
         workspace: &Arc<Workspace>,
-    ) -> Result<(), TaskExecutionError> {
+        out: OW,
+        err: EW,
+    ) -> Result<(), TaskExecutionError>
+    where
+        OW: io::Write,
+        EW: io::Write
+    {
         let dep_edges = &compute_dependency_edges(&nodes, workspace.as_ref())?;
 
         if let Some(cyclic_node) = has_cycle(dep_edges) {
@@ -662,7 +684,7 @@ impl TaskExecutor {
 
         let mut in_progress_jobs: HashSet<Arc<str>> = HashSet::new();
         let mut completed_jobs: HashSet<Arc<str>> = HashSet::new();
-        let mut concurrent_io = ConcurrentIO::new();
+        let mut concurrent_io = ConcurrentIO::new(out, err);
 
         let mut remaining_jobs = nodes;
 

--- a/src/execute/execute.rs
+++ b/src/execute/execute.rs
@@ -562,11 +562,11 @@ impl TaskExecutor {
         &mut self,
         workspace: &Workspace,
         tools: T,
-        pio: &IO
+        pio: &IO,
     ) -> Result<(), TaskExecutionError>
     where
         T: Iterator<Item = &'a Arc<str>>,
-        IO: ProcessIO
+        IO: ProcessIO,
     {
         self.ensure_worker_threads();
 
@@ -584,11 +584,11 @@ impl TaskExecutor {
         &mut self,
         workspace: &Workspace,
         tasks: T,
-        pio: &IO
+        pio: &IO,
     ) -> Result<(), TaskExecutionError>
     where
         T: Iterator<Item = &'a Arc<str>>,
-        IO: ProcessIO
+        IO: ProcessIO,
     {
         self.ensure_worker_threads();
 
@@ -606,11 +606,11 @@ impl TaskExecutor {
         &mut self,
         workspace: &Workspace,
         tasks: T,
-        pio: &IO
+        pio: &IO,
     ) -> Result<(), TaskExecutionError>
     where
         T: Iterator<Item = &'a Arc<str>>,
-        IO: ProcessIO
+        IO: ProcessIO,
     {
         self.ensure_worker_threads();
 
@@ -629,11 +629,11 @@ impl TaskExecutor {
         workspace: &Workspace,
         envs: E,
         args: &Vec<Arc<str>>,
-        pio: &IO
+        pio: &IO,
     ) -> Result<(), TaskExecutionError>
     where
         E: Iterator<Item = &'a Arc<str>>,
-        IO: ProcessIO
+        IO: ProcessIO,
     {
         self.ensure_worker_threads();
 
@@ -651,9 +651,10 @@ impl TaskExecutor {
         &mut self,
         nodes: HashMap<Arc<str>, ExecutorJob>,
         workspace: &Arc<Workspace>,
-        pio: &IO
+        pio: &IO,
     ) -> Result<(), TaskExecutionError>
-    where IO: ProcessIO
+    where
+        IO: ProcessIO,
     {
         let dep_edges = &compute_dependency_edges(&nodes, workspace.as_ref())?;
 

--- a/src/execute/job_io.rs
+++ b/src/execute/job_io.rs
@@ -87,7 +87,7 @@ impl <OW: io::Write, EW: io::Write> ConcurrentIO<OW, EW> {
         let job_opt = self.jobs.get_mut(job_id);
         if let Some(job) = job_opt {
             if is_active {
-                write!(self.out, "{}", text);
+                let _ = write!(self.out, "{}", text);
             } else {
                 if let TrackedJobState::Complete = job.job_state {
                     return;
@@ -109,7 +109,7 @@ impl <OW: io::Write, EW: io::Write> ConcurrentIO<OW, EW> {
             if is_active {
                 match job.show_stdout {
                     TaskOutputCondition::Always => {
-                        write!(self.out, "{}", text);
+                        let _ = write!(self.out, "{}", text);
                     }
                     TaskOutputCondition::OnFail => {
                         job.on_fail_buffer.push(Output::Stdout(text));
@@ -137,7 +137,7 @@ impl <OW: io::Write, EW: io::Write> ConcurrentIO<OW, EW> {
             if is_active {
                 match job.show_stdout {
                     TaskOutputCondition::Always => {
-                        write!(self.err, "{}", text);
+                        let _ = write!(self.err, "{}", text);
                     }
                     TaskOutputCondition::OnFail => {
                         job.on_fail_buffer.push(Output::Stderr(text));
@@ -236,7 +236,7 @@ impl <OW: io::Write, EW: io::Write> ConcurrentIO<OW, EW> {
                 match output {
                     Output::Stdout(s) => match job.show_stdout {
                         TaskOutputCondition::Always => {
-                            write!(self.out, "{}", s);
+                            let _ = write!(self.out, "{}", s);
                         }
                         TaskOutputCondition::OnFail => {
                             job.on_fail_buffer.push(Output::Stdout(s));
@@ -245,7 +245,7 @@ impl <OW: io::Write, EW: io::Write> ConcurrentIO<OW, EW> {
                     },
                     Output::Stderr(s) => match job.show_stderr {
                         TaskOutputCondition::Always => {
-                            write!(self.err, "{}", s);
+                            let _ = write!(self.err, "{}", s);
                         }
                         TaskOutputCondition::OnFail => {
                             job.on_fail_buffer.push(Output::Stderr(s));
@@ -253,7 +253,7 @@ impl <OW: io::Write, EW: io::Write> ConcurrentIO<OW, EW> {
                         TaskOutputCondition::Never => { /* Ignore */ }
                     },
                     Output::Status(s) => {
-                        write!(self.out, "{}", s);
+                        let _ = write!(self.out, "{}", s);
                     }
                 }
             }
@@ -261,13 +261,13 @@ impl <OW: io::Write, EW: io::Write> ConcurrentIO<OW, EW> {
                 for output in job.on_fail_buffer.drain(..) {
                     match output {
                         Output::Stdout(s) => {
-                            write!(self.out, "{}", s);
+                            let _ = write!(self.out, "{}", s);
                         }
                         Output::Stderr(s) => {
-                            write!(self.err, "{}", s);
+                            let _ = write!(self.err, "{}", s);
                         }
                         Output::Status(s) => {
-                            write!(self.out, "{}", s);
+                            let _ = write!(self.out, "{}", s);
                         }
                     }
                 }

--- a/src/execute/job_io.rs
+++ b/src/execute/job_io.rs
@@ -38,20 +38,20 @@ pub struct ConcurrentIO<OW: io::Write, EW: io::Write> {
     jobs: HashMap<Arc<str>, TrackedJob>,
     active_job: Option<Arc<str>>,
     out: OW,
-    err: EW
+    err: EW,
 }
 
-impl <OW: io::Write, EW: io::Write> ConcurrentIO<OW, EW> {
+impl<OW: io::Write, EW: io::Write> ConcurrentIO<OW, EW> {
     pub fn new(out: OW, err: EW) -> ConcurrentIO<OW, EW>
     where
         OW: io::Write,
-        EW: io::Write
+        EW: io::Write,
     {
         ConcurrentIO {
             jobs: HashMap::new(),
             active_job: None,
             out,
-            err
+            err,
         }
     }
 
@@ -276,7 +276,7 @@ impl <OW: io::Write, EW: io::Write> ConcurrentIO<OW, EW> {
     }
 }
 
-impl <OW: io::Write, EW: io::Write> Drop for ConcurrentIO<OW, EW> {
+impl<OW: io::Write, EW: io::Write> Drop for ConcurrentIO<OW, EW> {
     fn drop(&mut self) {
         for (_job_id, job) in self.jobs.iter_mut() {
             match job.job_state {

--- a/src/execute/job_io.rs
+++ b/src/execute/job_io.rs
@@ -5,6 +5,7 @@
 
 use std::{
     collections::HashMap,
+    io,
     sync::{Arc, Condvar, Mutex},
 };
 
@@ -33,16 +34,24 @@ struct TrackedJob {
     failed: bool,
 }
 
-pub struct ConcurrentIO {
+pub struct ConcurrentIO<OW: io::Write, EW: io::Write> {
     jobs: HashMap<Arc<str>, TrackedJob>,
     active_job: Option<Arc<str>>,
+    out: OW,
+    err: EW
 }
 
-impl ConcurrentIO {
-    pub fn new() -> ConcurrentIO {
+impl <OW: io::Write, EW: io::Write> ConcurrentIO<OW, EW> {
+    pub fn new(out: OW, err: EW) -> ConcurrentIO<OW, EW>
+    where
+        OW: io::Write,
+        EW: io::Write
+    {
         ConcurrentIO {
             jobs: HashMap::new(),
             active_job: None,
+            out,
+            err
         }
     }
 
@@ -78,7 +87,7 @@ impl ConcurrentIO {
         let job_opt = self.jobs.get_mut(job_id);
         if let Some(job) = job_opt {
             if is_active {
-                print!("{}", text);
+                write!(self.out, "{}", text);
             } else {
                 if let TrackedJobState::Complete = job.job_state {
                     return;
@@ -100,7 +109,7 @@ impl ConcurrentIO {
             if is_active {
                 match job.show_stdout {
                     TaskOutputCondition::Always => {
-                        print!("{}", text);
+                        write!(self.out, "{}", text);
                     }
                     TaskOutputCondition::OnFail => {
                         job.on_fail_buffer.push(Output::Stdout(text));
@@ -128,7 +137,7 @@ impl ConcurrentIO {
             if is_active {
                 match job.show_stdout {
                     TaskOutputCondition::Always => {
-                        eprint!("{}", text);
+                        write!(self.err, "{}", text);
                     }
                     TaskOutputCondition::OnFail => {
                         job.on_fail_buffer.push(Output::Stderr(text));
@@ -227,7 +236,7 @@ impl ConcurrentIO {
                 match output {
                     Output::Stdout(s) => match job.show_stdout {
                         TaskOutputCondition::Always => {
-                            print!("{}", s);
+                            write!(self.out, "{}", s);
                         }
                         TaskOutputCondition::OnFail => {
                             job.on_fail_buffer.push(Output::Stdout(s));
@@ -236,7 +245,7 @@ impl ConcurrentIO {
                     },
                     Output::Stderr(s) => match job.show_stderr {
                         TaskOutputCondition::Always => {
-                            eprint!("{}", s);
+                            write!(self.err, "{}", s);
                         }
                         TaskOutputCondition::OnFail => {
                             job.on_fail_buffer.push(Output::Stderr(s));
@@ -244,7 +253,7 @@ impl ConcurrentIO {
                         TaskOutputCondition::Never => { /* Ignore */ }
                     },
                     Output::Status(s) => {
-                        print!("{}", s);
+                        write!(self.out, "{}", s);
                     }
                 }
             }
@@ -252,13 +261,13 @@ impl ConcurrentIO {
                 for output in job.on_fail_buffer.drain(..) {
                     match output {
                         Output::Stdout(s) => {
-                            print!("{}", s);
+                            write!(self.out, "{}", s);
                         }
                         Output::Stderr(s) => {
-                            eprint!("{}", s);
+                            write!(self.err, "{}", s);
                         }
                         Output::Status(s) => {
-                            print!("{}", s);
+                            write!(self.out, "{}", s);
                         }
                     }
                 }
@@ -267,7 +276,7 @@ impl ConcurrentIO {
     }
 }
 
-impl Drop for ConcurrentIO {
+impl <OW: io::Write, EW: io::Write> Drop for ConcurrentIO<OW, EW> {
     fn drop(&mut self) {
         for (_job_id, job) in self.jobs.iter_mut() {
             match job.job_state {

--- a/src/execute/task_job.rs
+++ b/src/execute/task_job.rs
@@ -603,6 +603,7 @@ mod tests {
         let tmpdir = mktemp::Temp::new_dir().unwrap();
 
         let workspace_config = Arc::new(WorkspaceConfig {
+            init: None,
             workspace_dir: PathBuf::from("."),
             root_projects: vec![String::from(".")],
             vars: HashMap::new(),

--- a/src/project_def/artifact.rs
+++ b/src/project_def/artifact.rs
@@ -3,11 +3,11 @@
 //
 // This program is licensed under the GPLv3.0 license (https://github.com/jdarais/cobble/blob/main/COPYING)
 
-use std::{borrow::Cow, collections::HashMap};
 use std::fmt;
 use std::sync::Arc;
+use std::{borrow::Cow, collections::HashMap};
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::project_def::validate::validate_is_string;
 
@@ -157,8 +157,16 @@ impl<'lua> mlua::FromLua<'lua> for Artifacts {
 impl From<ArtifactsRecord> for Artifacts {
     fn from(value: ArtifactsRecord) -> Self {
         Artifacts {
-            files: value.files.iter().map(|f| Arc::<str>::from(f.1.as_str())).collect(),
-            calc: value.calc.iter().map(|c| Arc::<str>::from(c.1.as_str())).collect()
+            files: value
+                .files
+                .iter()
+                .map(|f| Arc::<str>::from(f.1.as_str()))
+                .collect(),
+            calc: value
+                .calc
+                .iter()
+                .map(|c| Arc::<str>::from(c.1.as_str()))
+                .collect(),
         }
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,4 +4,5 @@
 // This program is licensed under the GPLv3.0 license (https://github.com/jdarais/cobble/blob/main/COPYING)
 
 pub mod hash;
+pub mod process_io;
 pub mod onscopeexit;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,5 +4,5 @@
 // This program is licensed under the GPLv3.0 license (https://github.com/jdarais/cobble/blob/main/COPYING)
 
 pub mod hash;
-pub mod process_io;
 pub mod onscopeexit;
+pub mod process_io;

--- a/src/util/process_io.rs
+++ b/src/util/process_io.rs
@@ -16,22 +16,24 @@ enum Output {
 
 #[derive(Clone)]
 pub struct IOBuffer {
-    buffer: Arc<Mutex<Vec<Output>>>
+    buffer: Arc<Mutex<Vec<Output>>>,
 }
 
 #[derive(Clone)]
 pub struct IOBufferOut {
-    buffer: Arc<Mutex<Vec<Output>>>
+    buffer: Arc<Mutex<Vec<Output>>>,
 }
 
 #[derive(Clone)]
 pub struct IOBufferErr {
-    buffer: Arc<Mutex<Vec<Output>>>
+    buffer: Arc<Mutex<Vec<Output>>>,
 }
 
 impl IOBuffer {
     pub fn new() -> IOBuffer {
-        IOBuffer { buffer: Arc::new(Mutex::new(Vec::new())) }
+        IOBuffer {
+            buffer: Arc::new(Mutex::new(Vec::new())),
+        }
     }
 
     pub fn flush(&mut self) -> io::Result<()> {
@@ -57,11 +59,15 @@ impl ProcessIO for IOBuffer {
     type EW = IOBufferErr;
 
     fn out(&self) -> IOBufferOut {
-        IOBufferOut { buffer: self.buffer.clone() }
+        IOBufferOut {
+            buffer: self.buffer.clone(),
+        }
     }
 
     fn err(&self) -> IOBufferErr {
-        IOBufferErr { buffer: self.buffer.clone() }
+        IOBufferErr {
+            buffer: self.buffer.clone(),
+        }
     }
 }
 
@@ -104,4 +110,3 @@ impl ProcessIO for StandardIO {
         io::stderr()
     }
 }
-

--- a/src/util/process_io.rs
+++ b/src/util/process_io.rs
@@ -1,0 +1,107 @@
+use std::io;
+use std::sync::{Arc, Mutex};
+
+pub trait ProcessIO {
+    type OW: io::Write;
+    type EW: io::Write;
+
+    fn out(&self) -> Self::OW;
+    fn err(&self) -> Self::EW;
+}
+
+enum Output {
+    Stdout(Vec<u8>),
+    Stderr(Vec<u8>),
+}
+
+#[derive(Clone)]
+pub struct IOBuffer {
+    buffer: Arc<Mutex<Vec<Output>>>
+}
+
+#[derive(Clone)]
+pub struct IOBufferOut {
+    buffer: Arc<Mutex<Vec<Output>>>
+}
+
+#[derive(Clone)]
+pub struct IOBufferErr {
+    buffer: Arc<Mutex<Vec<Output>>>
+}
+
+impl IOBuffer {
+    pub fn new() -> IOBuffer {
+        IOBuffer { buffer: Arc::new(Mutex::new(Vec::new())) }
+    }
+
+    pub fn flush(&mut self) -> io::Result<()> {
+        let mut buffer_lock = self.buffer.lock().unwrap();
+        let mut out = io::stdout().lock();
+        let mut err = io::stderr().lock();
+        for output in buffer_lock.drain(..) {
+            match output {
+                Output::Stdout(buf) => {
+                    io::Write::write(&mut out, buf.as_slice())?;
+                }
+                Output::Stderr(buf) => {
+                    io::Write::write(&mut err, buf.as_slice())?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ProcessIO for IOBuffer {
+    type OW = IOBufferOut;
+    type EW = IOBufferErr;
+
+    fn out(&self) -> IOBufferOut {
+        IOBufferOut { buffer: self.buffer.clone() }
+    }
+
+    fn err(&self) -> IOBufferErr {
+        IOBufferErr { buffer: self.buffer.clone() }
+    }
+}
+
+impl io::Write for IOBufferOut {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut buffer_lock = self.buffer.lock().unwrap();
+        buffer_lock.push(Output::Stdout(Vec::from(buf)));
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl io::Write for IOBufferErr {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut buffer_lock = self.buffer.lock().unwrap();
+        buffer_lock.push(Output::Stderr(Vec::from(buf)));
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct StandardIO;
+
+impl ProcessIO for StandardIO {
+    type OW = io::Stdout;
+    type EW = io::Stderr;
+
+    fn out(&self) -> io::Stdout {
+        io::stdout()
+    }
+
+    fn err(&self) -> io::Stderr {
+        io::stderr()
+    }
+}
+


### PR DESCRIPTION
closes #5 

Rather than build in the ability for cobble to fetch remote resources, this PR simply allows a workspace to specify an "init workspace", which will be executed prior to the main workspace running.  The init workspace works just like the main workspace, and can fetch remote resources by using a tool of the user's choosing.

At some point in the future, it may make sense to standardize and create a built-in mechanism for doing this.