### PR TITLE
Add 'modules_dir' config value

### DIFF
--- a/docs/cobble/docs/concepts.md
+++ b/docs/cobble/docs/concepts.md
@@ -171,9 +171,9 @@ Note that the built-in `cmd` tool interprets file paths as relative to the proje
 
 ## Modules
 
-Cobble sets the workspace root as the module path root for including modules.  This means that if you have a lua module that exists at `cobble_modules/python.lua`, you can include that in any lua script with `require("cobble_modules.python")`.  Leveraging modules is a great way to share logic for defining different types of projects.
+Cobble uses the `modules_dir` configuration value, (defaulting to the workspace root,) to set the module path root for including modules.  This means that if you have a lua module that exists at `cobble_modules/python.lua`, you can include that in any lua script with `require("cobble_modules.python")`, or if `modules_dir` is set to `cobble_modules`, it can be included simply with `require("python")`.  Leveraging modules is a great way to share project definition logic and other utilities across projects.
 
-Note that using native modules may work, but is not officially supported.  Cobble is designed to make workspaces as portable and self-contained as possible, and use of native lua modules runs counter to this philosophy.
+Note that using native modules may work, but is not officially supported.  This may change in the future.
 
 ### Cobble modules
 

--- a/docs/cobble/docs/workspace-def.md
+++ b/docs/cobble/docs/workspace-def.md
@@ -6,6 +6,7 @@ The presence of a `cobble.toml` file marks the root of a Cobble workspace.  The 
 
 - `root_projects`: _array[string]_ - A list of root project paths to include in the workspace (Default = `["."]`)
 - `num_threads`: _int_ - Number of threads to use for executing tasks (Default = `5`)
+- `modules_dir`: _string_ - Directory to search for lua modules in.  `modules_dir` must exist within the workspace. (Default = `"."`, i.e. the workspace root is used as the module directory.)
 - `stdout`: _"always" | "never" | "on_fail"_ - When to display stdout output from tasks (Default = `"on_fail"`)
 - `stderr`: _"always" | "never" | "on_fail"_ - When to display stderr output from tasks (Default = `"on_fail"`)
 - `output`: _"always" | "never" | "on_fail"_ - Sets both `stdout` and `stderr`.  If `stdout` or `stderr` properties are present, they will take precedence over `output`.
@@ -18,6 +19,7 @@ An example of what a `cobble.toml` file might look like:
 ```toml
 root_projects = [ "./project_a", "./project_b" ]
 num_threads = 10
+modules_dir = "cobble"
 
 [vars]
 foo = "bar"

--- a/examples/python_flit_mono/workspace/cobble.toml
+++ b/examples/python_flit_mono/workspace/cobble.toml
@@ -1,4 +1,4 @@
-
+modules_dir = "cobble"
 
 [vars]
 project.version = "0.1.0"

--- a/examples/python_flit_mono/workspace/pkg1/project.lua
+++ b/examples/python_flit_mono/workspace/pkg1/project.lua
@@ -1,4 +1,4 @@
-local python = require("cobble.python")
+local python = require("python")
 
 python.python_project {
     constraints_file_calc = "/constraints_file_name",

--- a/examples/python_flit_mono/workspace/pkg2/project.lua
+++ b/examples/python_flit_mono/workspace/pkg2/project.lua
@@ -1,4 +1,4 @@
-local python = require("cobble.python")
+local python = require("python")
 
 python.python_project {
     constraints_file_calc = "/constraints_file_name",

--- a/examples/python_flit_mono/workspace/project.lua
+++ b/examples/python_flit_mono/workspace/project.lua
@@ -1,6 +1,6 @@
 local tblext = require("tblext")
 local path = require("path")
-local python = require("cobble.python")
+local python = require("python")
 
 project_dir("pkg1")
 project_dir("pkg2")

--- a/src/bin/cobl/commands/clean.rs
+++ b/src/bin/cobl/commands/clean.rs
@@ -52,6 +52,7 @@ pub fn clean_command<'a>(input: CleanCommandInput) -> anyhow::Result<()> {
 
     let projects = load_projects(
         config.workspace_dir.as_path(),
+        config.modules_dir.as_path(),
         config.root_projects.iter().map(|s| s.as_str()),
     )?;
     let mut workspace = create_workspace(projects.values());

--- a/src/bin/cobl/commands/env.rs
+++ b/src/bin/cobl/commands/env.rs
@@ -46,6 +46,7 @@ pub fn run_env_command(input: RunEnvInput) -> anyhow::Result<()> {
 
     let projects = load_projects(
         config.workspace_dir.as_path(),
+        config.modules_dir.as_path(),
         config.root_projects.iter().map(|s| s.as_str()),
     )?;
     let mut workspace = create_workspace(projects.values());

--- a/src/bin/cobl/commands/list.rs
+++ b/src/bin/cobl/commands/list.rs
@@ -32,6 +32,7 @@ pub fn list_command(input: ListCommandInput) -> anyhow::Result<()> {
 
     let projects = load_projects(
         config.workspace_dir.as_path(),
+        config.modules_dir.as_path(),
         config.root_projects.iter().map(|s| s.as_str()),
     )?;
 

--- a/src/bin/cobl/commands/run.rs
+++ b/src/bin/cobl/commands/run.rs
@@ -147,6 +147,7 @@ pub fn run<IO: ProcessIO>(
 
     let projects = load_projects(
         config.workspace_dir.as_path(),
+        config.modules_dir.as_path(),
         config.root_projects.iter().map(|s| s.as_str()),
     )?;
     let mut workspace = create_workspace(projects.values());

--- a/src/bin/cobl/commands/show.rs
+++ b/src/bin/cobl/commands/show.rs
@@ -51,6 +51,7 @@ pub fn show_task_command(input: ShowTaskInput) -> anyhow::Result<()> {
 
     let projects = load_projects(
         config.workspace_dir.as_path(),
+        config.modules_dir.as_path(),
         config.root_projects.iter().map(|s| s.as_str()),
     )?;
     let mut workspace = create_workspace(projects.values());

--- a/src/bin/cobl/commands/tool.rs
+++ b/src/bin/cobl/commands/tool.rs
@@ -47,6 +47,7 @@ pub fn check_tool_command(input: CheckToolInput) -> anyhow::Result<()> {
 
     let projects = load_projects(
         config.workspace_dir.as_path(),
+        config.modules_dir.as_path(),
         config.root_projects.iter().map(|s| s.as_str()),
     )?;
     let workspace = create_workspace(projects.values());

--- a/src/bin/cobl/main.rs
+++ b/src/bin/cobl/main.rs
@@ -132,6 +132,7 @@ fn run_from_dir(path: &Path) -> anyhow::Result<()> {
 
     let projects = load_projects(
         config.workspace_dir.as_path(),
+        config.modules_dir.as_path(),
         config.root_projects.iter().map(|s| s.as_str()),
     )
     .unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ pub struct WorkspaceInit {
 #[derive(Debug)]
 pub struct WorkspaceConfig {
     pub workspace_dir: PathBuf,
+    pub modules_dir: PathBuf,
     pub root_projects: Vec<String>,
     pub vars: serde_json::Map<String, serde_json::Value>,
     pub force_run_tasks: bool,
@@ -110,6 +111,14 @@ pub fn parse_workspace_config(
     let mut config: toml::Table = config_str
         .parse()
         .map_err(|e| WorkspaceConfigError::ParseError(format!("Error parsing config: {}", e)))?;
+
+    // Modules Directory
+    let modules_dir_opt: Option<toml::Value> = config.remove("modules_dir");
+    let modules_dir_str: String = match modules_dir_opt {
+        Some(dir) => dir.try_into().map_err(|e| WorkspaceConfigError::ValueError(format!("at 'modules_dir': {e}")))?,
+        None => String::from(".")
+    };
+    let modules_dir = PathBuf::from(modules_dir_str);
 
     // Root Projects
     let root_projects_opt: Option<toml::Value> = config.remove("root_projects");
@@ -296,6 +305,7 @@ pub fn parse_workspace_config(
 
     Ok(WorkspaceConfig {
         workspace_dir: PathBuf::from(config_path.parent().unwrap_or_else(|| Path::new("."))),
+        modules_dir,
         root_projects,
         vars,
         force_run_tasks: false,

--- a/src/execute/task_job.rs
+++ b/src/execute/task_job.rs
@@ -697,6 +697,7 @@ mod tests {
         let workspace_config = Arc::new(WorkspaceConfig {
             init: None,
             workspace_dir: PathBuf::from("."),
+            modules_dir: PathBuf::from("."),
             root_projects: vec![String::from(".")],
             vars: serde_json::Map::new(),
             force_run_tasks: false,
@@ -706,7 +707,7 @@ mod tests {
             show_stderr: TaskOutputCondition::Always,
         });
         let workspace_dir: Arc<Path> = PathBuf::from(".").into();
-        let lua = create_lua_env(workspace_dir.as_ref()).unwrap();
+        let lua = create_lua_env(workspace_dir.as_ref(), Path::new(".")).unwrap();
         init_lua_for_task_executor(&lua).unwrap();
 
         let db_env = Arc::new(

--- a/src/execute/worker.rs
+++ b/src/execute/worker.rs
@@ -56,7 +56,7 @@ fn poll_next_task(
 }
 
 pub fn run_task_executor_worker(args: TaskExecutorWorkerArgs) {
-    let lua = create_lua_env(args.workspace_config.workspace_dir.as_path())
+    let lua = create_lua_env(args.workspace_config.workspace_dir.as_path(), args.workspace_config.modules_dir.as_path())
         .expect("Lua environment creation should always succeed");
     init_lua_for_task_executor(&lua)
         .expect("Initializing lua environment for a task executor should always succeed");

--- a/src/load.rs
+++ b/src/load.rs
@@ -215,12 +215,13 @@ pub fn extract_project_defs(
 
 pub fn load_projects<'a, P>(
     workspace_dir: &Path,
+    modules_dir: &Path,
     root_projects: P,
 ) -> mlua::Result<BTreeMap<String, Project>>
 where
     P: Iterator<Item = &'a str>,
 {
-    let project_def_lua = create_lua_env(workspace_dir)?;
+    let project_def_lua = create_lua_env(workspace_dir, modules_dir)?;
 
     init_lua_for_project_config(&project_def_lua, workspace_dir)?;
 
@@ -240,7 +241,7 @@ mod tests {
     #[test]
     fn test_load_subproject_def() {
         let tmpdir = mktemp::Temp::new_dir().unwrap();
-        let lua = create_lua_env(tmpdir.as_path()).unwrap();
+        let lua = create_lua_env(tmpdir.as_path(), Path::new(".")).unwrap();
 
         init_lua_for_project_config(&lua, tmpdir.as_path()).unwrap();
 

--- a/src/lua/json.rs
+++ b/src/lua/json.rs
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_map() {
-        let lua = create_lua_env(Path::new(".")).unwrap();
+        let lua = create_lua_env(Path::new("."), Path::new(".")).unwrap();
         let json_lib = lua.create_userdata(JsonLib).unwrap();
 
         let result: (Vec<String>, Vec<i64>) = lua.load(r#"

--- a/src/lua/lua_env.rs
+++ b/src/lua/lua_env.rs
@@ -3,6 +3,7 @@
 //
 // This program is licensed under the GPLv3.0 license (https://github.com/jdarais/cobble/blob/main/COPYING)
 
+use std::borrow::Cow;
 use std::ffi::OsString;
 use std::path::Path;
 
@@ -17,7 +18,7 @@ use crate::lua::toml::TomlLib;
 
 pub const COBBLE_JOB_INTERACTIVE_ENABLED: &str = "COBBLE_JOB_INTERACTIVE_ENABLED";
 
-pub fn create_lua_env(workspace_dir: &Path) -> mlua::Result<Lua> {
+pub fn create_lua_env(workspace_dir: &Path, modules_dir: &Path) -> mlua::Result<Lua> {
     let lua = unsafe { Lua::unsafe_new() };
     let preload_table: mlua::Table = lua
         .globals()
@@ -91,12 +92,23 @@ pub fn create_lua_env(workspace_dir: &Path) -> mlua::Result<Lua> {
     let ordered_map_loader = lua.load(&ordered_map_source[..]).into_function()?;
     preload_table.set("ordered_map", ordered_map_loader)?;
 
+    let workspace_dir_full_path = dunce::canonicalize(workspace_dir)
+        .map_err(|e| mlua::Error::runtime(format!("Error determining workspace directory from {}: {}", workspace_dir.display(), e)))?;
+
+    let modules_dir_full_path: Cow<Path> = dunce::canonicalize(workspace_dir.join(modules_dir))
+        .map(|p| Cow::Owned(p))
+        .unwrap_or(Cow::Borrowed(workspace_dir));
+
+    if !modules_dir_full_path.starts_with(&workspace_dir_full_path) {
+        return Err(mlua::Error::runtime(format!("Modules directory must be inside the workspace. (Got {})", modules_dir_full_path.display())));
+    }
+
     {
         let mut module_search_path = OsString::new();
-        module_search_path.push(workspace_dir.as_os_str());
+        module_search_path.push(modules_dir_full_path.as_os_str());
         module_search_path.push(std::path::MAIN_SEPARATOR_STR);
         module_search_path.push("?.lua;");
-        module_search_path.push(workspace_dir.as_os_str());
+        module_search_path.push(modules_dir_full_path.as_os_str());
         module_search_path.push(std::path::MAIN_SEPARATOR_STR);
         module_search_path.push("?");
         module_search_path.push(std::path::MAIN_SEPARATOR_STR);

--- a/src/lua/lua_env.rs
+++ b/src/lua/lua_env.rs
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn test_shell_command() {
-        let lua_env = create_lua_env(Path::new(".")).unwrap();
+        let lua_env = create_lua_env(Path::new("."), Path::new(".")).unwrap();
         let chunk = lua_env.load(r#"require("cmd")({"echo", "hi!"})"#);
 
         let result: Table = chunk.eval().unwrap();

--- a/src/project_def/action.rs
+++ b/src/project_def/action.rs
@@ -367,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_validate_and_convert_arg_list_action() {
-        let lua = create_lua_env(Path::new(".")).unwrap();
+        let lua = create_lua_env(Path::new("."), Path::new(".")).unwrap();
         let action_val: mlua::Value = lua
             .load(r#"{ tool = "cmd", "echo", "hi", "there" }"#)
             .eval()
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn test_validate_and_convert_function_action() {
-        let lua = create_lua_env(Path::new(".")).unwrap();
+        let lua = create_lua_env(Path::new("."), Path::new(".")).unwrap();
         let action_val: mlua::Value = lua
             .load(
                 r#"
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_mixed_function_and_string_sequence_fails_validation() {
-        let lua = create_lua_env(Path::new(".")).unwrap();
+        let lua = create_lua_env(Path::new("."), Path::new(".")).unwrap();
         let action_val: mlua::Value = lua
             .load(
                 r#"

--- a/src/project_def/build_env.rs
+++ b/src/project_def/build_env.rs
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn test_build_env_def_from_lua_table() {
-        let lua = create_lua_env(Path::new(".")).unwrap();
+        let lua = create_lua_env(Path::new("."), Path::new(".")).unwrap();
 
         let build_env_table: mlua::Table = lua
             .load(


### PR DESCRIPTION
Allow configuration to determine the root directory from which module paths are resolved.  This will make it easier to consume modules without having to use a require string that is specific to the structure of a specific project.